### PR TITLE
[Feature] Add confirmation dialog to delete and reset to factory default

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-02-23T15:21:16.109Z\n"
-"PO-Revision-Date: 2021-02-23T15:21:16.109Z\n"
+"POT-Creation-Date: 2021-02-23T15:29:49.625Z\n"
+"PO-Revision-Date: 2021-02-23T15:29:49.625Z\n"
 
 msgid "Field {{field}} cannot be blank"
 msgstr ""
@@ -72,6 +72,12 @@ msgid "Access"
 msgstr ""
 
 msgid "Summary"
+msgstr ""
+
+msgid "Are you sure you want to delete the selected modules?"
+msgstr ""
+
+msgid "This action cannot be reversed"
 msgstr ""
 
 msgid "Deleting modules"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-02-23T13:34:25.207Z\n"
-"PO-Revision-Date: 2021-02-23T13:34:25.208Z\n"
+"POT-Creation-Date: 2021-02-23T14:20:28.398Z\n"
+"PO-Revision-Date: 2021-02-23T14:20:28.398Z\n"
 
 msgid "Field {{field}} cannot be blank"
 msgstr ""
@@ -74,10 +74,19 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
+msgid "Cancel"
+msgstr ""
+
+msgid "Delete modules"
+msgstr ""
+
 msgid "Edit contents of {{name}}"
 msgstr ""
 
 msgid "Installing application"
+msgstr ""
+
+msgid "Reset app to factory settings"
 msgstr ""
 
 msgid "Initialize project in POEditor"
@@ -111,9 +120,6 @@ msgid "Install app"
 msgstr ""
 
 msgid "Restore to factory settings"
-msgstr ""
-
-msgid "Reset app to factory settings"
 msgstr ""
 
 msgid "Back"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-02-23T14:20:28.398Z\n"
-"PO-Revision-Date: 2021-02-23T14:20:28.398Z\n"
+"POT-Creation-Date: 2021-02-23T15:21:16.109Z\n"
+"PO-Revision-Date: 2021-02-23T15:21:16.109Z\n"
 
 msgid "Field {{field}} cannot be blank"
 msgstr ""
@@ -72,6 +72,9 @@ msgid "Access"
 msgstr ""
 
 msgid "Summary"
+msgstr ""
+
+msgid "Deleting modules"
 msgstr ""
 
 msgid "Cancel"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-02-23T13:34:25.207Z\n"
+"POT-Creation-Date: 2021-02-23T14:20:28.398Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -75,10 +75,20 @@ msgstr ""
 msgid "Summary"
 msgstr "Fin"
 
+msgid "Cancel"
+msgstr ""
+
+#, fuzzy
+msgid "Delete modules"
+msgstr "Eliminar modulo"
+
 msgid "Edit contents of {{name}}"
 msgstr "Editar contenidos de {{name}}"
 
 msgid "Installing application"
+msgstr ""
+
+msgid "Reset app to factory settings"
 msgstr ""
 
 msgid "Initialize project in POEditor"
@@ -112,9 +122,6 @@ msgid "Install app"
 msgstr ""
 
 msgid "Restore to factory settings"
-msgstr ""
-
-msgid "Reset app to factory settings"
 msgstr ""
 
 msgid "Back"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-02-23T14:20:28.398Z\n"
+"POT-Creation-Date: 2021-02-23T15:21:16.109Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -74,6 +74,10 @@ msgstr ""
 
 msgid "Summary"
 msgstr "Fin"
+
+#, fuzzy
+msgid "Deleting modules"
+msgstr "Eliminar modulo"
 
 msgid "Cancel"
 msgstr ""

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-02-23T15:21:16.109Z\n"
+"POT-Creation-Date: 2021-02-23T15:29:49.625Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -53,7 +53,6 @@ msgstr ""
 msgid "Field must have a value"
 msgstr "El campo debe tener un valor"
 
-#, fuzzy
 msgid "Welcome page"
 msgstr "Bienvenido"
 
@@ -75,16 +74,20 @@ msgstr ""
 msgid "Summary"
 msgstr "Fin"
 
-#, fuzzy
+msgid "Are you sure you want to delete the selected modules?"
+msgstr ""
+
+msgid "This action cannot be reversed"
+msgstr ""
+
 msgid "Deleting modules"
-msgstr "Eliminar modulo"
+msgstr "Eliminando modulo"
 
 msgid "Cancel"
 msgstr ""
 
-#, fuzzy
 msgid "Delete modules"
-msgstr "Eliminar modulo"
+msgstr "Eliminar modulos"
 
 msgid "Edit contents of {{name}}"
 msgstr "Editar contenidos de {{name}}"
@@ -170,9 +173,8 @@ msgstr ""
 msgid "Training app"
 msgstr ""
 
-#, fuzzy
 msgid "Create module"
-msgstr "Eliminar modulo"
+msgstr "Crear modulo"
 
 msgid "Continue Tutorial"
 msgstr "Continuar el tutorial"
@@ -197,13 +199,11 @@ msgstr ""
 msgid "Well done!"
 msgstr "Bien hecho!"
 
-#, fuzzy
 msgid "You've completed the {{name}} tutorial!"
 msgstr "Has completado el tutorial {{name}}"
 
-#, fuzzy
 msgid "Back to tutorial"
-msgstr "Salir del tutorial"
+msgstr "Vovler al tutorial"
 
 msgid "Finish"
 msgstr ""

--- a/src/data/clients/storage/StorageClient.ts
+++ b/src/data/clients/storage/StorageClient.ts
@@ -42,7 +42,7 @@ export abstract class StorageClient {
             for (const element of elements) {
                 const advancedElement = _.pick(element, advancedProperties);
                 await this.saveObject(`${key}-${element.id}`, advancedElement);
-            }   
+            }
         }
     }
 

--- a/src/webapp/CompositionRoot.tsx
+++ b/src/webapp/CompositionRoot.tsx
@@ -17,7 +17,7 @@ import { UpdateSettingsPermissionsUseCase } from "../domain/usecases/UpdateSetti
 import { UpdateUserProgressUseCase } from "../domain/usecases/UpdateUserProgressUseCase";
 import { UploadFileUseCase } from "../domain/usecases/UploadFileUseCase";
 import { SearchUsersUseCase } from "../domain/usecases/SearchUsersUseCase";
-import {ResetModuleToFactorySettingsUseCase } from "../domain/usecases/ResetModuleToFactorySettingsUseCase";
+import { ResetModuleToFactorySettingsUseCase } from "../domain/usecases/ResetModuleToFactorySettingsUseCase";
 
 export function getCompositionRoot(baseUrl: string) {
     const configRepository = new Dhis2ConfigRepository(baseUrl);

--- a/src/webapp/components/module-list-table/ModuleListTable.tsx
+++ b/src/webapp/components/module-list-table/ModuleListTable.tsx
@@ -35,23 +35,22 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = ({ rows, refreshR
 
     const [selection, setSelection] = useState<TableSelection[]>([]);
     const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
-
     const [editContentsDialogProps, updateEditContentsDialog] = useState<MarkdownEditorDialogProps | null>(null);
 
     const deleteModules = useCallback(
         async (ids: string[]) => {
-            const numModules = ids.length > 1 ? "these modules" : "this module";
             updateDialog({
-                title: `Are you sure you want to delete ${numModules}? This action cannot be reversed.`,
+                title: i18n.t("Are you sure you want to delete the selected modules?"),
+                description: i18n.t("This action cannot be reversed"),
                 onCancel: () => {
                     updateDialog(null);
                 },
                 onSave: async () => {
                     updateDialog(null);
-                    loading.show(true, i18n.t(`Deleting modules`));
+                    loading.show(true, i18n.t("Deleting modules"));
                     await usecases.modules.delete(ids);
                     await refreshRows();
-                    snackbar.success(`Successfully deleted modules`);
+                    snackbar.success("Successfully deleted modules");
                     loading.reset();
                     setSelection([]);
                 },

--- a/src/webapp/components/module-list-table/ModuleListTable.tsx
+++ b/src/webapp/components/module-list-table/ModuleListTable.tsx
@@ -140,30 +140,26 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = ({ rows, refreshR
         [rows, snackbar, usecases]
     );
 
-    const resetToFactorySettings = useCallback(
-        async (row: ListItem) => {
-            updateDialog(null);
-            loading.show(true, i18n.t(`Resetting ${row.name} to factory settings`));
-            await usecases.modules.resetToFactorySettings(row.dhisAppKey);
-            snackbar.success(`Successfully resetted ${row.name} to factory settings`);
-            loading.reset();
-            await refreshRows();
-        },
-        [rows]
-    );
-    const showFactorySettingsConfirmationDialog = (ids: string[]) => {
+    const showFactorySettingsConfirmationDialog = useCallback((ids: string[]) => {
         const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
         if (!row) return;
+
         updateDialog({
-            title: `Are you sure you want to reset ${row.name} to its factory settings? This action cannot be reversed.`,
-            onCancel: () => {
+            title: i18n.t("Are you sure you want to reset {{name}} to its factory settings?", row),
+            description: i18n.t("This action cannot be reversed."),
+            onCancel: () => updateDialog(null),
+            onSave: async () => {
                 updateDialog(null);
+                loading.show(true, i18n.t(`Resetting ${row.name} to factory settings`));
+                await usecases.modules.resetToFactorySettings(row.dhisAppKey);
+                snackbar.success(`Successfully resetted ${row.name} to factory settings`);
+                loading.reset();
+                await refreshRows();
             },
-            onSave: () => resetToFactorySettings(row),
             cancelText: i18n.t("Cancel"),
             saveText: i18n.t("Reset app to factory settings"),
         });
-    };
+    }, []);
 
     const publishTranslations = useCallback(
         async (ids: string[]) => {
@@ -307,7 +303,6 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = ({ rows, refreshR
             editContents,
             installApp,
             publishTranslations,
-            resetToFactorySettings,
         ]
     );
 

--- a/src/webapp/components/module-list-table/ModuleListTable.tsx
+++ b/src/webapp/components/module-list-table/ModuleListTable.tsx
@@ -315,20 +315,7 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = ({ rows, refreshR
             publishTranslations,
             resetToFactorySettings        ]
     );
-    /*
-            {factorySettingsDialog && (
-                <ConfirmationDialog
-                title={`Are you sure you want to reset ${factorySettingsDialog.name} to its factory settings? This action cannot be reversed.`}
-                isOpen={true}
-                maxWidth={"md"}
-                fullWidth={true}
-                onCancel={() => setFactorySettingsDialog(undefined)}
-                onSave={() => resetToFactorySettings(factorySettingsDialog)}
-                saveText={i18n.t("Reset app to factory settings")}
-            >
-            </ConfirmationDialog>
-            )}
-    */
+
     return (
         <PageWrapper>
             {editContentsDialogProps && <MarkdownEditorDialog {...editContentsDialogProps} />}

--- a/src/webapp/components/module-list-table/ModuleListTable.tsx
+++ b/src/webapp/components/module-list-table/ModuleListTable.tsx
@@ -7,7 +7,7 @@ import {
     TableSelection,
     TableState,
     useLoading,
-    useSnackbar
+    useSnackbar,
 } from "@eyeseetea/d2-ui-components";
 import { Icon } from "@material-ui/core";
 import GetAppIcon from "@material-ui/icons/GetApp";
@@ -36,10 +36,7 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = ({ rows, refreshR
     const [selection, setSelection] = useState<TableSelection[]>([]);
     const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
 
-    const [
-        editContentsDialogProps,
-        updateEditContentsDialog,
-    ] = useState<MarkdownEditorDialogProps | null>(null);
+    const [editContentsDialogProps, updateEditContentsDialog] = useState<MarkdownEditorDialogProps | null>(null);
 
     const deleteModules = useCallback(
         async (ids: string[]) => {
@@ -61,7 +58,6 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = ({ rows, refreshR
                 cancelText: i18n.t("Cancel"),
                 saveText: i18n.t("Delete modules"),
             });
-            
         },
         [usecases]
     );
@@ -153,7 +149,6 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = ({ rows, refreshR
             snackbar.success(`Successfully resetted ${row.name} to factory settings`);
             loading.reset();
             await refreshRows();
-            
         },
         [rows]
     );
@@ -169,7 +164,7 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = ({ rows, refreshR
             cancelText: i18n.t("Cancel"),
             saveText: i18n.t("Reset app to factory settings"),
         });
-    }
+    };
 
     const publishTranslations = useCallback(
         async (ids: string[]) => {
@@ -313,14 +308,15 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = ({ rows, refreshR
             editContents,
             installApp,
             publishTranslations,
-            resetToFactorySettings        ]
+            resetToFactorySettings,
+        ]
     );
 
     return (
         <PageWrapper>
             {editContentsDialogProps && <MarkdownEditorDialog {...editContentsDialogProps} />}
             {dialogProps && <ConfirmationDialog isOpen={true} maxWidth={"xl"} {...dialogProps} />}
-            
+
             <ObjectsTable<ListItem>
                 rows={rows}
                 columns={columns}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes ["Add confirmation dialog to delete action and restore to factory default"](https://app.clickup.com/t/ef3xf3) in ClickUp

### :memo: Implementation 
- Added state props to add ConfirmationDialogProps to delete and reset to factory settings actions
- Also added loading and snackbar to delete action like in the reset to factory settings one
 
### :art: Screenshots
No visual change
<img width="1265" alt="Screen Shot 2021-02-23 at 2 54 46 PM" src="https://user-images.githubusercontent.com/20975863/108853514-1b3fe700-75e7-11eb-84d5-6e381441ef2f.png">


### :fire: How to test it? (If there is any special consideration or the reviewer does not know how to test it)

### :bookmark_tabs: Others

-   [ ] Any change in the [API repo](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
-   [ ] Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?