### PR TITLE
Fix landing page nodes ordering

### DIFF
--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -93,11 +93,11 @@ export const LandingPageListTable: React.FC<{ nodes: LandingNode[]; isLoading?: 
             const allNodes = flattenRows(nodes);
 
             const firstNode = allNodes.find(({ id }) => id === ids[0]);
-            if (!firstNode?.order) return;
+            if (firstNode?.order === undefined) return;
 
             const parent = allNodes.find(({ id }) => id === firstNode?.parent);
             const secondNode = parent?.children[firstNode?.order + orderChange];
-            if (!secondNode?.order) return;
+            if (secondNode?.order === undefined) return;
 
             await usecases.landings.swapOrder(firstNode, secondNode);
             await reload();


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/1u0dfvw

### :memo: Implementation

- [x] Fix landing page nodes ordering

The problem was to use the conditions similar to `if (!firstNode?.order) return;` in the move function because this condition introduces the bug for nodes with index 0 because 0 is a falsy condition and for these conditions index 0 nodes move down not work.

I have seen a possible architecture improvement for the future, moving reordering logic from component to the use case because it's an application business logic.

### :art: Screenshots

### :fire: How to test it? (If there is any special consideration or the reviewer does not know how to test it)

### :bookmark_tabs: Others

-   [ ] Any change in the [API repo](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
-   [ ] Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?
