### PR TITLE
[PERFORMANCE] Add TextFieldOnBlur for performance and use on GeneralInfoStep

### DIFF
--- a/src/webapp/components/form/TextFieldOnBlur.tsx
+++ b/src/webapp/components/form/TextFieldOnBlur.tsx
@@ -1,0 +1,44 @@
+import { TextField, TextFieldProps } from "@material-ui/core";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+/* Wrap TextField with those two changes:
+
+- props.onChange is called on blur, not on every keystroke, this way the UI is much more responsive.
+*/
+
+type TextFieldOnBlurProps = TextFieldProps & {
+    value: string;
+};
+
+const TextFieldOnBlur: React.FC<TextFieldOnBlurProps> = props => {
+    const { onChange } = props;
+    // Use props.value as initial value for the initial state but also react to changes from the parent
+    const propValue = props.value;
+    const prevPropValue = useRef(propValue);
+    const [value, setValue] = useState<string>(propValue);
+
+    useEffect(() => {
+        if (propValue !== prevPropValue.current) {
+            setValue(propValue);
+            prevPropValue.current = propValue;
+        }
+    }, [propValue, prevPropValue, value]);
+
+    const callParentOnChange = useCallback<NonNullable<TextFieldProps["onBlur"]>>(
+        ev => {
+            if (onChange) onChange(ev);
+        },
+        [onChange]
+    );
+
+    const setValueFromEvent = useCallback(
+        (ev: React.ChangeEvent<{ value: string }>) => {
+            setValue(ev.target.value);
+        },
+        [setValue]
+    );
+
+    return <TextField {...props} value={value} onBlur={callParentOnChange} onChange={setValueFromEvent} />;
+};
+
+export default React.memo(TextFieldOnBlur);

--- a/src/webapp/components/module-creation-wizard/steps/GeneralInfoStep.tsx
+++ b/src/webapp/components/module-creation-wizard/steps/GeneralInfoStep.tsx
@@ -1,6 +1,5 @@
 import { MultipleDropdown } from "@eyeseetea/d2-ui-components";
 import i18n from "@eyeseetea/d2-ui-components/locales";
-import { TextField } from "@material-ui/core";
 import { Dictionary } from "lodash";
 import React, { ChangeEvent, useCallback, useState } from "react";
 import styled from "styled-components";
@@ -10,6 +9,7 @@ import { updateTranslation } from "../../../../domain/helpers/TrainingModuleHelp
 import { ComponentParameter } from "../../../../types/utils";
 import { imagesMimeType } from "../../../../utils/files";
 import { useAppContext } from "../../../contexts/app-context";
+import TextFieldOnBlur from "../../form/TextFieldOnBlur";
 import { ModuleCreationWizardStepProps } from "./index";
 
 export const GeneralInfoStep: React.FC<ModuleCreationWizardStepProps> = ({ module, onChange, isEdit }) => {
@@ -72,7 +72,7 @@ export const GeneralInfoStep: React.FC<ModuleCreationWizardStepProps> = ({ modul
     return (
         <React.Fragment>
             <Row>
-                <TextField
+                <TextFieldOnBlur
                     disabled={!!isEdit}
                     fullWidth={true}
                     label={i18n.t("Code *")}
@@ -84,7 +84,7 @@ export const GeneralInfoStep: React.FC<ModuleCreationWizardStepProps> = ({ modul
             </Row>
 
             <Row>
-                <TextField
+                <TextFieldOnBlur
                     fullWidth={true}
                     label={i18n.t("Name *")}
                     value={module.name.referenceValue}
@@ -122,7 +122,7 @@ export const GeneralInfoStep: React.FC<ModuleCreationWizardStepProps> = ({ modul
             <Row>
                 <h3>{i18n.t("Launch application")}</h3>
 
-                <TextField
+                <TextFieldOnBlur
                     fullWidth={true}
                     label={i18n.t("DHIS2 application")}
                     value={module.dhisLaunchUrl}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/21w2wc5

### :memo: Implementation

Forms using MUI `<TextField onChange={...} />` re-render the whole form on every keystroke. The standard workaround is to use a component wrapper that keeps state internally and only notifies the parent on blur. I've found this component in `metadata-synchronization`. I've reused it a minor modifications: keep the `onChange` signature so the wrapper is a drop-in replacement of `TextField`.

### :fire: How to test it?

Modules -> New/Edit module -> General Information. Test in code/name/url.