### PR TITLE
use default app namespace

### DIFF
--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -1,6 +1,7 @@
 declare module "@dhis2/d2-i18n" {
     export function t(value: string, namespace?: object): string;
     export function changeLanguage(locale: string);
+    export function setDefaultNamespace(namespace: string);
 }
 
 declare module "d2" {

--- a/src/webapp/contexts/app-context.tsx
+++ b/src/webapp/contexts/app-context.tsx
@@ -7,6 +7,7 @@ import { CompositionRoot } from "../CompositionRoot";
 import { AppState } from "../entities/AppState";
 import { AppRoute } from "../router/AppRoute";
 import { cacheImages } from "../utils/image-cache";
+import i18n from "../../locales";
 
 const AppContext = React.createContext<AppContextState | null>(null);
 
@@ -78,6 +79,7 @@ export const AppContextProvider: React.FC<AppContextProviderProps> = ({
 
 export function useAppContext(): UseAppContextResult {
     const context = useContext(AppContext);
+    i18n.setDefaultNamespace("training-app");
     if (!context) throw new Error("Context not initialized");
 
     const {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694ubx3x

### :memo: Implementation
- [x] Update i18n types
- [x] Set default namespace in `app-context.ts`

### :video_camera: Screenshots/Screen capture
<img width="1135" alt="Screenshot 2024-06-25 at 20 19 30" src="https://github.com/EyeSeeTea/training-app/assets/37223065/73ed6a08-a270-4135-87c5-f78103cd4daf">


### :fire: How to test it? (If there is any special consideration or the reviewer does not know how to test it)

### :bookmark_tabs: Others

-   [ ] Any change in the [API repo](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
-   [ ] Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?

#8694ubx3x