### PR TITLE
Move dependencies to peerDependencies for training-component

### DIFF
--- a/build-lib.js
+++ b/build-lib.js
@@ -34,20 +34,48 @@ function generateIndexJsWithTypes() {
     }
 }
 
-function removeDependenciesFromPackage() {
+function updatePackageJson() {
     const packageJsonPath = path.join(__dirname, "package.json");
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
     const packageJson2 = { ...packageJson, name: packageJson.name.replace(/-app$/, "-component") };
-
-    delete packageJson2.dependencies["react-router"];
-    delete packageJson2.dependencies["react-router-dom"];
+    delete packageJson2["manifest.webapp"];
+    moveToPeerDependencies(packageJson2);
     const destinationPath = path.join(distPath, "package.json");
     fs.writeFileSync(destinationPath, JSON.stringify(packageJson2, null, 2));
     console.log("package.json copied");
 }
 
+function moveToPeerDependencies(packageJson) {
+    const depsToMove = [
+        ["react-router", "react-router-dom", "react", "react-dom"],
+        ["@material-ui/core", "@material-ui/icons", "@material-ui/lab", "@material-ui/styles"],
+        [
+            "@dhis2/app-runtime",
+            "@dhis2/d2-i18n",
+            "@dhis2/d2-i18n-extract",
+            "@dhis2/d2-i18n-generate",
+            "@dhis2/d2-ui-core",
+            "@dhis2/d2-ui-forms",
+            "@dhis2/ui",
+        ],
+        ["@eyeseetea/d2-api", "@eyeseetea/d2-ui-components"],
+        ["purify-ts"],
+        ["d2", "d2-manifest"],
+    ].flat();
+    depsToMove.forEach(dep => {
+        if (packageJson.dependencies[dep]) {
+            const depVersion = packageJson.dependencies[dep];
+            packageJson.peerDependencies[dep] = depVersion.startsWith("^") ? depVersion : `^${depVersion}`;
+            delete packageJson.dependencies[dep];
+        } else {
+            console.warn(`Dependency ${dep} not found in dependencies`);
+        }
+    });
+    return packageJson;
+}
+
 function start() {
-    removeDependenciesFromPackage();
+    updatePackageJson();
     validateDistFolder();
     generateIndexJsWithTypes();
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Related: https://app.clickup.com/t/86954h5tm

### :memo: Implementation

While adding the component in metadata-sync for the WMR flavor, I detected an increase in the bundle size - so I thought It could be a good idea to move some dependencies to peerDependencies.

Identified dependencies common to most of our DHIS projects, and updated `build-lib.js` to move them to peerDependencies. 
When moving the dependency (that is pinned to a exact version) added a "^" in the peerDependency version to allow for other minor releases.

Also removed the "manifest.webapp" entry from the components's package.json.

### :fire: How to test it? (If there is any special consideration or the reviewer does not know how to test it)

- I tested the library in the branches:
  - CPR - feature/trainingapptest
  - https://github.com/EyeSeeTea/dhis2-app-skeleton/tree/feature/trainingapptest
  - https://github.com/EyeSeeTea/metadata-synchronization/tree/feature/wmr-sync
- Used [yalc](https://github.com/wclr/yalc) to "publish" the component locally and load it from the projects
- Built the apps with sourcemaps enabled and used [source-map-explorer](https://github.com/danvk/source-map-explorer/) to measure changes - size went from ~1mb to ~240kb for the component
