### PR TITLE
Fix i18n errors on release

### DIFF
--- a/src/utils/i18n-typed.ts
+++ b/src/utils/i18n-typed.ts
@@ -1,10 +1,19 @@
 import i18n from "../locales";
 
-export function getModuleForNamespace(namespace: string) {
+export interface I18nModule {
+    t: <Str extends string>(...args: I18nTArgs<Str>) => string;
+    changeLanguage: (lng: string, callback?: (err?: any, t?: any) => void) => void;
+}
+
+export function getModuleForNamespace(namespace: string): I18nModule {
     return {
         t: function <Str extends string>(...args: I18nTArgs<Str>): string {
             const [s, options] = args;
-            return i18n.t(s, { ...options, ns: namespace });
+            return i18n.t(s, {
+                ...options,
+                ns: namespace,
+                nsSeparator: options?.nsSeparator || undefined,
+            });
         },
         changeLanguage: i18n.changeLanguage.bind(i18n),
     };
@@ -14,9 +23,9 @@ type I18nTArgs<Str extends string> = Interpolations<Str> extends Record<string, 
     ? [Str] | [Str, Partial<Options>]
     : [Str, Interpolations<Str> & Partial<Options>];
 
-interface Options {
+export interface Options {
     ns: string; // namespace
-    nsSeparator: string | boolean; // By default, ":", which breaks strings containing that char
+    nsSeparator: string | false; // By default, ":", which breaks strings containing that char
     lng: string; // language
 }
 

--- a/src/utils/i18n-typed.ts
+++ b/src/utils/i18n-typed.ts
@@ -1,9 +1,9 @@
 import i18n from "../locales";
 
-export interface I18nModule {
+export type I18nModule = {
     t: <Str extends string>(...args: I18nTArgs<Str>) => string;
-    changeLanguage: (lng: string, callback?: (err?: any, t?: any) => void) => void;
-}
+    changeLanguage: (lng: string) => void;
+};
 
 export function getModuleForNamespace(namespace: string): I18nModule {
     return {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #86992gzeq [Problem when trying to publish training-app](https://app.clickup.com/t/86992gzeq)

### :memo: Implementation
- added nsSeparator handling to resolve false to undefined
- added type for getModuleForNamespace

NOTE:
- There seems to be some mismatch in the expected type for the prop `nsSeparator`. When generating translations (i18next-scanner), `false` was the only thing that worked to unset the default value of ":".
- `i18n.t` or the `TranslationFunction` accepts `TranslationOptions` where the prop is `nsSeparator?: string;` which is what's causing the issue during lib build

### :video_camera: Screenshots/Screen capture

### :fire: How to test it? (If there is any special consideration or the reviewer does not know how to test it)

### :bookmark_tabs: Others

-   [ ] Any change in the [API repo](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
-   [ ] Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?
