### PR TITLE
Feature/multiple landing pages

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-01-12T02:42:56.804Z\n"
-"PO-Revision-Date: 2026-01-12T02:42:56.804Z\n"
+"POT-Creation-Date: 2026-02-22T06:14:27.632Z\n"
+"PO-Revision-Date: 2026-02-22T06:14:27.632Z\n"
 
 msgid "Welcome to training on DHIS2"
 msgstr ""
@@ -403,9 +403,6 @@ msgstr ""
 msgid "Edit page"
 msgstr ""
 
-msgid "Sharing settings"
-msgstr ""
-
 msgid "Delete module"
 msgstr ""
 
@@ -419,9 +416,6 @@ msgid "Export module"
 msgstr ""
 
 msgid "Import modules"
-msgstr ""
-
-msgid "Page permissions"
 msgstr ""
 
 msgid "App is not installed in this instance"
@@ -438,6 +432,9 @@ msgstr ""
 msgid "Unable to update module contents"
 msgstr ""
 
+msgid "Unable to update page permissions"
+msgstr ""
+
 msgid "Unable to move item"
 msgstr ""
 
@@ -451,6 +448,9 @@ msgid "Unable to remove step"
 msgstr ""
 
 msgid "Unable to remove page"
+msgstr ""
+
+msgid "Page permissions"
 msgstr ""
 
 msgid "Help"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-04-07T11:18:42.330Z\n"
-"PO-Revision-Date: 2025-04-07T11:18:42.330Z\n"
+"POT-Creation-Date: 2025-08-06T13:32:25.208Z\n"
+"PO-Revision-Date: 2025-08-06T13:32:25.208Z\n"
 
 msgid "Welcome to training on DHIS2"
 msgstr ""
@@ -65,25 +65,25 @@ msgstr ""
 msgid "done"
 msgstr ""
 
-msgid "Export JSON translations"
-msgstr ""
-
-msgid "Import JSON translations"
-msgstr ""
-
 msgid "Close"
 msgstr ""
 
-msgid "Home page logo"
-msgstr ""
-
-msgid "Customize landing page text"
+msgid "Logo"
 msgstr ""
 
 msgid "Welcome message"
 msgstr ""
 
 msgid "Module selection"
+msgstr ""
+
+msgid "Export JSON translations"
+msgstr ""
+
+msgid "Import JSON translations"
+msgstr ""
+
+msgid "Customize main landing page"
 msgstr ""
 
 msgid "Exporting translations"
@@ -158,6 +158,9 @@ msgstr ""
 msgid "No"
 msgstr ""
 
+msgid "Access to landing page"
+msgstr ""
+
 msgid "Add section"
 msgstr ""
 
@@ -168,6 +171,9 @@ msgid "Add category"
 msgstr ""
 
 msgid "Edit"
+msgstr ""
+
+msgid "Sharing settings"
 msgstr ""
 
 msgid "Delete"
@@ -207,6 +213,44 @@ msgid "Save"
 msgstr ""
 
 msgid "Uploading file..."
+msgstr ""
+
+msgid "There are pending migrations"
+msgstr ""
+
+msgid "Migrations finished successfully, you may now continue to the app"
+msgstr ""
+
+msgid ""
+"There has been an error. You can either retry or contact your administrator "
+"if you think there has been an un recoverable error"
+msgstr ""
+
+msgid "Migrate instance"
+msgstr ""
+
+msgid "Migrating..."
+msgstr ""
+
+msgid "Continue to the App"
+msgstr ""
+
+msgid ""
+"The app needs to run pending migrations (from version {{instanceVersion}} "
+"to version {{appVersion}}) in order to continue. This may take a long time, "
+"make sure the process is not interrupted."
+msgstr ""
+
+msgid "Error"
+msgstr ""
+
+msgid "Continue to the app anyway"
+msgstr ""
+
+msgid ""
+"The database version ({{instanceVersion}}) is greater than the app version "
+"({{appVersion}}), cannot continue. Please contact the administrator to "
+"update the app."
 msgstr ""
 
 msgid "Home"
@@ -341,17 +385,6 @@ msgstr ""
 msgid "Exporting module(s)"
 msgstr ""
 
-msgid "App is not installed in this instance"
-msgstr ""
-
-msgid "Module does not support this DHIS2 version"
-msgstr ""
-
-msgid ""
-"There's a new version of this module, please reset to default values to "
-"update"
-msgstr ""
-
 msgid "Add module"
 msgstr ""
 
@@ -383,6 +416,35 @@ msgid "Export module"
 msgstr ""
 
 msgid "Import modules"
+msgstr ""
+
+msgid "App is not installed in this instance"
+msgstr ""
+
+msgid "Module does not support this DHIS2 version"
+msgstr ""
+
+msgid ""
+"There's a new version of this module, please reset to default values to "
+"update"
+msgstr ""
+
+msgid "Unable to update module contents"
+msgstr ""
+
+msgid "Unable to move item"
+msgstr ""
+
+msgid "Unable to add step"
+msgstr ""
+
+msgid "Unable to add page"
+msgstr ""
+
+msgid "Unable to remove step"
+msgstr ""
+
+msgid "Unable to remove page"
 msgstr ""
 
 msgid "Help"
@@ -512,16 +574,10 @@ msgstr ""
 msgid "First load can take a couple of minutes, please wait..."
 msgstr ""
 
-msgid "Accessible to {{users}} users and {{userGroups}} user groups"
+msgid "Module"
 msgstr ""
 
-msgid "Accessible to {{users}} users"
-msgstr ""
-
-msgid "Accessible to {{userGroups}} user groups"
-msgstr ""
-
-msgid "Only accessible to system administrators"
+msgid "Landing Page"
 msgstr ""
 
 msgid "Clean-up unused documents"
@@ -536,27 +592,6 @@ msgstr ""
 msgid "Proceed"
 msgstr ""
 
-msgid "Unable to update module contents"
-msgstr ""
-
-msgid "Unable to move item"
-msgstr ""
-
-msgid "Unable to add step"
-msgstr ""
-
-msgid "Unable to add page"
-msgstr ""
-
-msgid "Unable to remove step"
-msgstr ""
-
-msgid "Unable to remove page"
-msgstr ""
-
-msgid "General Settings"
-msgstr ""
-
 msgid "Access to Settings"
 msgstr ""
 
@@ -569,7 +604,7 @@ msgstr ""
 msgid "The list with all the existing  modules is hidden"
 msgstr ""
 
-msgid "Customize the landing page"
+msgid "Customize landing page selection"
 msgstr ""
 
 msgid "Update the logo or content"
@@ -581,5 +616,23 @@ msgstr ""
 msgid "There are {{total}} documents available to clean"
 msgstr ""
 
+msgid "General Settings"
+msgstr ""
+
 msgid "Training modules"
+msgstr ""
+
+msgid "Add Landing Page"
+msgstr ""
+
+msgid "Accessible to {{usersCount}} users and {{userGroupsCount}} user groups"
+msgstr ""
+
+msgid "Accessible to {{usersCount}} users"
+msgstr ""
+
+msgid "Accessible to {{userGroupsCount}} user groups"
+msgstr ""
+
+msgid "Only accessible to system administrators"
 msgstr ""

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Traning App - UI Interface\n"
-"POT-Creation-Date: 2025-04-07T11:18:42.330Z\n"
+"POT-Creation-Date: 2025-08-06T13:32:25.208Z\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -65,26 +65,27 @@ msgstr "Tutorial"
 msgid "done"
 msgstr "Hecho"
 
-msgid "Export JSON translations"
-msgstr "Exportar traducciones JSON"
-
-msgid "Import JSON translations"
-msgstr "Importar traducciones JSON"
-
 msgid "Close"
 msgstr "Cerrar"
 
-msgid "Home page logo"
-msgstr "Logotipo de la página de inicio"
-
-msgid "Customize landing page text"
-msgstr "Personalizar el texto de la página de destino"
+msgid "Logo"
+msgstr ""
 
 msgid "Welcome message"
 msgstr "Mensaje de bienvenida"
 
 msgid "Module selection"
 msgstr "Selección de módulo"
+
+msgid "Export JSON translations"
+msgstr "Exportar traducciones JSON"
+
+msgid "Import JSON translations"
+msgstr "Importar traducciones JSON"
+
+#, fuzzy
+msgid "Customize main landing page"
+msgstr "Personalizar la página de portada"
 
 msgid "Exporting translations"
 msgstr "Exportación de traducciones"
@@ -159,6 +160,10 @@ msgstr "Sí"
 msgid "No"
 msgstr "No"
 
+#, fuzzy
+msgid "Access to landing page"
+msgstr "Exportar la página de destino"
+
 msgid "Add section"
 msgstr "Añadir sección "
 
@@ -170,6 +175,10 @@ msgstr "Añadir categoría"
 
 msgid "Edit"
 msgstr "Editar"
+
+#, fuzzy
+msgid "Sharing settings"
+msgstr "Ajustes"
 
 msgid "Delete"
 msgstr "Borrar"
@@ -209,6 +218,45 @@ msgstr "Guardar"
 
 msgid "Uploading file..."
 msgstr "Subiendo archivo..."
+
+msgid "There are pending migrations"
+msgstr ""
+
+msgid "Migrations finished successfully, you may now continue to the app"
+msgstr ""
+
+msgid ""
+"There has been an error. You can either retry or contact your administrator "
+"if you think there has been an un recoverable error"
+msgstr ""
+
+msgid "Migrate instance"
+msgstr ""
+
+msgid "Migrating..."
+msgstr ""
+
+#, fuzzy
+msgid "Continue to the App"
+msgstr "Continuar el tutorial"
+
+msgid ""
+"The app needs to run pending migrations (from version {{instanceVersion}} to "
+"version {{appVersion}}) in order to continue. This may take a long time, "
+"make sure the process is not interrupted."
+msgstr ""
+
+msgid "Error"
+msgstr ""
+
+msgid "Continue to the app anyway"
+msgstr ""
+
+msgid ""
+"The database version ({{instanceVersion}}) is greater than the app version "
+"({{appVersion}}), cannot continue. Please contact the administrator to "
+"update the app."
+msgstr ""
 
 msgid "Home"
 msgstr "Inicio"
@@ -345,19 +393,6 @@ msgstr "Restablecer la aplicación a la configuración de fábrica"
 msgid "Exporting module(s)"
 msgstr "Exportando módulo(s)"
 
-msgid "App is not installed in this instance"
-msgstr "La aplicación no está instalada en esta instancia"
-
-msgid "Module does not support this DHIS2 version"
-msgstr "El módulo no es compatible con esta versión de DHIS2"
-
-msgid ""
-"There's a new version of this module, please reset to default values to "
-"update"
-msgstr ""
-"Hay una nueva versión de este módulo, por favor restablezca los valores por "
-"defecto para actualizar"
-
 msgid "Add module"
 msgstr "Añadir modulo"
 
@@ -390,6 +425,37 @@ msgstr "Exportar módulo"
 
 msgid "Import modules"
 msgstr "Importar módulos"
+
+msgid "App is not installed in this instance"
+msgstr "La aplicación no está instalada en esta instancia"
+
+msgid "Module does not support this DHIS2 version"
+msgstr "El módulo no es compatible con esta versión de DHIS2"
+
+msgid ""
+"There's a new version of this module, please reset to default values to "
+"update"
+msgstr ""
+"Hay una nueva versión de este módulo, por favor restablezca los valores por "
+"defecto para actualizar"
+
+msgid "Unable to update module contents"
+msgstr "No se puede actualizar el contenido del módulo"
+
+msgid "Unable to move item"
+msgstr "No se puede mover el artículo"
+
+msgid "Unable to add step"
+msgstr "No se puede añadir el paso"
+
+msgid "Unable to add page"
+msgstr "No se puede añadir la página"
+
+msgid "Unable to remove step"
+msgstr "No se puede eliminar el paso"
+
+msgid "Unable to remove page"
+msgstr "No se puede eliminar la página"
 
 msgid "Help"
 msgstr "Ayuda"
@@ -553,18 +619,13 @@ msgstr ""
 msgid "First load can take a couple of minutes, please wait..."
 msgstr "La primera carga puede tardar un par de minutos, por favor espere..."
 
-msgid "Accessible to {{users}} users and {{userGroups}} user groups"
-msgstr ""
-"Accesible para los usuarios {{users}} y los grupos de usuarios {{userGroups}}"
+#, fuzzy
+msgid "Module"
+msgstr "Módulos"
 
-msgid "Accessible to {{users}} users"
-msgstr "Accesible para los usuarios de {{users}}"
-
-msgid "Accessible to {{userGroups}} user groups"
-msgstr "Accesible a los grupos de usuarios {{userGroups}}"
-
-msgid "Only accessible to system administrators"
-msgstr "Sólo accesible para los administradores del sistema"
+#, fuzzy
+msgid "Landing Page"
+msgstr "Bienvenido"
 
 msgid "Clean-up unused documents"
 msgstr "Limpiar los documentos no utilizados"
@@ -578,27 +639,6 @@ msgstr "Documentos obsoletos borrados"
 msgid "Proceed"
 msgstr "Proceder"
 
-msgid "Unable to update module contents"
-msgstr "No se puede actualizar el contenido del módulo"
-
-msgid "Unable to move item"
-msgstr "No se puede mover el artículo"
-
-msgid "Unable to add step"
-msgstr "No se puede añadir el paso"
-
-msgid "Unable to add page"
-msgstr "No se puede añadir la página"
-
-msgid "Unable to remove step"
-msgstr "No se puede eliminar el paso"
-
-msgid "Unable to remove page"
-msgstr "No se puede eliminar la página"
-
-msgid "General Settings"
-msgstr "Configuración general"
-
 msgid "Access to Settings"
 msgstr "Acceso a la configuración"
 
@@ -611,8 +651,9 @@ msgstr "Una lista con todos los módulos existentes es visible"
 msgid "The list with all the existing  modules is hidden"
 msgstr "La lista con todos los módulos existentes está oculta"
 
-msgid "Customize the landing page"
-msgstr "Personalizar la página de portada"
+#, fuzzy
+msgid "Customize landing page selection"
+msgstr "Personalizar el texto de la página de destino"
 
 msgid "Update the logo or content"
 msgstr "Actualizar el logotipo o el contenido"
@@ -623,5 +664,31 @@ msgstr "No hay documentos no utilizados que limpiar"
 msgid "There are {{total}} documents available to clean"
 msgstr "Hay {{total}} documentos disponibles para limpiar"
 
+msgid "General Settings"
+msgstr "Configuración general"
+
 msgid "Training modules"
 msgstr "Módulos de formación"
+
+#, fuzzy
+msgid "Add Landing Page"
+msgstr "Bienvenido"
+
+#, fuzzy
+msgid "Accessible to {{usersCount}} users and {{userGroupsCount}} user groups"
+msgstr ""
+"Accesible para los usuarios {{users}} y los grupos de usuarios {{userGroups}}"
+
+#, fuzzy
+msgid "Accessible to {{usersCount}} users"
+msgstr "Accesible para los usuarios de {{users}}"
+
+#, fuzzy
+msgid "Accessible to {{userGroupsCount}} user groups"
+msgstr "Accesible a los grupos de usuarios {{userGroups}}"
+
+msgid "Only accessible to system administrators"
+msgstr "Sólo accesible para los administradores del sistema"
+
+#~ msgid "Home page logo"
+#~ msgstr "Logotipo de la página de inicio"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Traning App - UI Interface\n"
-"POT-Creation-Date: 2026-01-12T02:42:56.804Z\n"
+"POT-Creation-Date: 2026-02-22T06:14:27.632Z\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -408,9 +408,6 @@ msgstr "Duplicar módulo"
 msgid "Edit page"
 msgstr "Editar página"
 
-msgid "Sharing settings"
-msgstr "Ajustes de uso compartido"
-
 msgid "Delete module"
 msgstr "Eliminar modulo"
 
@@ -440,6 +437,10 @@ msgstr ""
 "defecto para actualizar"
 
 msgid "Unable to update module contents"
+msgstr "No se puede actualizar el contenido del módulo"
+
+#, fuzzy
+msgid "Unable to update page permissions"
 msgstr "No se puede actualizar el contenido del módulo"
 
 msgid "Unable to move item"
@@ -674,7 +675,9 @@ msgid "Add Landing Page"
 msgstr "Agregar página de destino"
 
 msgid "Accessible to {{usersCount}} users and {{userGroupsCount}} user groups"
-msgstr "Accesible para {{usersCount}} usuarios y {{userGroupsCount}} grupos de usuarios"
+msgstr ""
+"Accesible para {{usersCount}} usuarios y {{userGroupsCount}} grupos de "
+"usuarios"
 
 msgid "Accessible to {{usersCount}} users"
 msgstr "Accesible para {{usersCount}} usuarios"
@@ -684,4 +687,3 @@ msgstr "Accesible a {{userGroupsCount}} grupos de usuarios"
 
 msgid "Only accessible to system administrators"
 msgstr "Sólo accesible para los administradores del sistema"
-

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -85,7 +85,7 @@ msgstr "Importar traducciones JSON"
 
 #, fuzzy
 msgid "Customize main landing page"
-msgstr "Personalizar la página de portada"
+msgstr "Personalizar la página principal"
 
 msgid "Exporting translations"
 msgstr "Exportación de traducciones"
@@ -160,9 +160,8 @@ msgstr "Sí"
 msgid "No"
 msgstr "No"
 
-#, fuzzy
 msgid "Access to landing page"
-msgstr "Exportar la página de destino"
+msgstr "Acceso a la página de destino"
 
 msgid "Add section"
 msgstr "Añadir sección "
@@ -176,9 +175,8 @@ msgstr "Añadir categoría"
 msgid "Edit"
 msgstr "Editar"
 
-#, fuzzy
 msgid "Sharing settings"
-msgstr "Ajustes"
+msgstr "Configuración para compartir"
 
 msgid "Delete"
 msgstr "Borrar"
@@ -236,9 +234,8 @@ msgstr ""
 msgid "Migrating..."
 msgstr ""
 
-#, fuzzy
 msgid "Continue to the App"
-msgstr "Continuar el tutorial"
+msgstr "Continuar con la aplicación"
 
 msgid ""
 "The app needs to run pending migrations (from version {{instanceVersion}} to "
@@ -619,13 +616,11 @@ msgstr ""
 msgid "First load can take a couple of minutes, please wait..."
 msgstr "La primera carga puede tardar un par de minutos, por favor espere..."
 
-#, fuzzy
 msgid "Module"
-msgstr "Módulos"
+msgstr "Módulo"
 
-#, fuzzy
 msgid "Landing Page"
-msgstr "Bienvenido"
+msgstr "Página de destino"
 
 msgid "Clean-up unused documents"
 msgstr "Limpiar los documentos no utilizados"
@@ -651,9 +646,8 @@ msgstr "Una lista con todos los módulos existentes es visible"
 msgid "The list with all the existing  modules is hidden"
 msgstr "La lista con todos los módulos existentes está oculta"
 
-#, fuzzy
 msgid "Customize landing page selection"
-msgstr "Personalizar el texto de la página de destino"
+msgstr "Personalizar la selección de la página de destino"
 
 msgid "Update the logo or content"
 msgstr "Actualizar el logotipo o el contenido"
@@ -670,25 +664,18 @@ msgstr "Configuración general"
 msgid "Training modules"
 msgstr "Módulos de formación"
 
-#, fuzzy
 msgid "Add Landing Page"
-msgstr "Bienvenido"
+msgstr "Agregar página de destino"
 
-#, fuzzy
 msgid "Accessible to {{usersCount}} users and {{userGroupsCount}} user groups"
-msgstr ""
-"Accesible para los usuarios {{users}} y los grupos de usuarios {{userGroups}}"
+msgstr "Accesible para {{usersCount}} usuarios y {{userGroupsCount}} grupos de usuarios"
 
-#, fuzzy
 msgid "Accessible to {{usersCount}} users"
-msgstr "Accesible para los usuarios de {{users}}"
+msgstr "Accesible para {{usersCount}} usuarios"
 
-#, fuzzy
 msgid "Accessible to {{userGroupsCount}} user groups"
-msgstr "Accesible a los grupos de usuarios {{userGroups}}"
+msgstr "Accesible a {{userGroupsCount}} grupos de usuarios"
 
 msgid "Only accessible to system administrators"
 msgstr "Sólo accesible para los administradores del sistema"
 
-#~ msgid "Home page logo"
-#~ msgstr "Logotipo de la página de inicio"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -83,9 +83,8 @@ msgstr "Exportation des traductions en JSON"
 msgid "Import JSON translations"
 msgstr "Importer des traductions JSON"
 
-#, fuzzy
 msgid "Customize main landing page"
-msgstr "Personnaliser la page de couverture"
+msgstr "Personnaliser la page d'accueil principale"
 
 msgid "Exporting translations"
 msgstr "Exportation des traductions"
@@ -160,9 +159,8 @@ msgstr "Oui"
 msgid "No"
 msgstr "Pas de"
 
-#, fuzzy
 msgid "Access to landing page"
-msgstr "Exportation de la page de renvoi"
+msgstr "Accès à la page d’atterrissage"
 
 msgid "Add section"
 msgstr "Ajouter une section"
@@ -176,9 +174,8 @@ msgstr "Ajouter une catégorie"
 msgid "Edit"
 msgstr "Modifier"
 
-#, fuzzy
 msgid "Sharing settings"
-msgstr "Paramètres"
+msgstr "Paramètres de partage"
 
 msgid "Delete"
 msgstr "Supprimer"
@@ -236,9 +233,8 @@ msgstr ""
 msgid "Migrating..."
 msgstr ""
 
-#, fuzzy
 msgid "Continue to the App"
-msgstr "Continuer le tutoriel"
+msgstr "Continuer vers l’application"
 
 msgid ""
 "The app needs to run pending migrations (from version {{instanceVersion}} to "
@@ -620,11 +616,9 @@ msgid "First load can take a couple of minutes, please wait..."
 msgstr ""
 "Le premier chargement peut prendre quelques minutes, veuillez patienter..."
 
-#, fuzzy
 msgid "Module"
-msgstr "Modules"
+msgstr "Module"
 
-#, fuzzy
 msgid "Landing Page"
 msgstr "Page d'atterrissage"
 
@@ -652,9 +646,8 @@ msgstr "Une liste avec tous les modules existants est visible"
 msgid "The list with all the existing  modules is hidden"
 msgstr "La liste avec tous les modules existants est cachée"
 
-#, fuzzy
 msgid "Customize landing page selection"
-msgstr "Personnaliser le texte de la page d'accueil"
+msgstr "Personnaliser la sélection de la page d'atterrissage"
 
 msgid "Update the logo or content"
 msgstr "Mettre à jour le logo ou le contenu"
@@ -671,26 +664,17 @@ msgstr "Paramètres généraux"
 msgid "Training modules"
 msgstr "Modules de formation"
 
-#, fuzzy
 msgid "Add Landing Page"
-msgstr "Page d'atterrissage"
+msgstr "Ajouter une page d'atterrissage"
 
-#, fuzzy
 msgid "Accessible to {{usersCount}} users and {{userGroupsCount}} user groups"
-msgstr ""
-"Accessible aux utilisateurs {{users}} et aux groupes d'utilisateurs "
-"{{userGroups}}."
+msgstr "Accessible à {{usersCount}} utilisateurs et à {{userGroupsCount}} groupes d'utilisateurs"
 
-#, fuzzy
 msgid "Accessible to {{usersCount}} users"
-msgstr "Accessible aux {{users}} utilisateurs"
+msgstr "Accessible à {{usersCount}} utilisateurs"
 
-#, fuzzy
 msgid "Accessible to {{userGroupsCount}} user groups"
-msgstr "Accessible aux groupes d'utilisateurs {{userGroups}}"
+msgstr "Accessible à {{userGroupsCount}} groupes d'utilisateurs"
 
 msgid "Only accessible to system administrators"
 msgstr "Uniquement accessible aux administrateurs du système"
-
-#~ msgid "Home page logo"
-#~ msgstr "Logo de la page d'accueil"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Traning App - UI Interface\n"
-"POT-Creation-Date: 2025-04-07T11:18:42.330Z\n"
+"POT-Creation-Date: 2025-08-06T13:32:25.208Z\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -65,26 +65,27 @@ msgstr "Tutoriels"
 msgid "done"
 msgstr "Fait"
 
-msgid "Export JSON translations"
-msgstr "Exportation des traductions en JSON"
-
-msgid "Import JSON translations"
-msgstr "Importer des traductions JSON"
-
 msgid "Close"
 msgstr "Fermer"
 
-msgid "Home page logo"
-msgstr "Logo de la page d'accueil"
-
-msgid "Customize landing page text"
-msgstr "Personnaliser le texte de la page d'accueil"
+msgid "Logo"
+msgstr ""
 
 msgid "Welcome message"
 msgstr "Message de bienvenue"
 
 msgid "Module selection"
 msgstr "Sélection du module"
+
+msgid "Export JSON translations"
+msgstr "Exportation des traductions en JSON"
+
+msgid "Import JSON translations"
+msgstr "Importer des traductions JSON"
+
+#, fuzzy
+msgid "Customize main landing page"
+msgstr "Personnaliser la page de couverture"
 
 msgid "Exporting translations"
 msgstr "Exportation des traductions"
@@ -159,6 +160,10 @@ msgstr "Oui"
 msgid "No"
 msgstr "Pas de"
 
+#, fuzzy
+msgid "Access to landing page"
+msgstr "Exportation de la page de renvoi"
+
 msgid "Add section"
 msgstr "Ajouter une section"
 
@@ -170,6 +175,10 @@ msgstr "Ajouter une catégorie"
 
 msgid "Edit"
 msgstr "Modifier"
+
+#, fuzzy
+msgid "Sharing settings"
+msgstr "Paramètres"
 
 msgid "Delete"
 msgstr "Supprimer"
@@ -209,6 +218,45 @@ msgstr "Sauvez"
 
 msgid "Uploading file..."
 msgstr "Téléchargement du fichier..."
+
+msgid "There are pending migrations"
+msgstr ""
+
+msgid "Migrations finished successfully, you may now continue to the app"
+msgstr ""
+
+msgid ""
+"There has been an error. You can either retry or contact your administrator "
+"if you think there has been an un recoverable error"
+msgstr ""
+
+msgid "Migrate instance"
+msgstr ""
+
+msgid "Migrating..."
+msgstr ""
+
+#, fuzzy
+msgid "Continue to the App"
+msgstr "Continuer le tutoriel"
+
+msgid ""
+"The app needs to run pending migrations (from version {{instanceVersion}} to "
+"version {{appVersion}}) in order to continue. This may take a long time, "
+"make sure the process is not interrupted."
+msgstr ""
+
+msgid "Error"
+msgstr ""
+
+msgid "Continue to the app anyway"
+msgstr ""
+
+msgid ""
+"The database version ({{instanceVersion}}) is greater than the app version "
+"({{appVersion}}), cannot continue. Please contact the administrator to "
+"update the app."
+msgstr ""
 
 msgid "Home"
 msgstr "Accueil"
@@ -345,19 +393,6 @@ msgstr "Réinitialiser l'application aux paramètres d'usine"
 msgid "Exporting module(s)"
 msgstr "Module(s) d'exportation"
 
-msgid "App is not installed in this instance"
-msgstr "L'application n'est pas installée dans ce cas"
-
-msgid "Module does not support this DHIS2 version"
-msgstr "Le module ne supporte pas cette version du DHIS2"
-
-msgid ""
-"There's a new version of this module, please reset to default values to "
-"update"
-msgstr ""
-"Il y a une nouvelle version de ce module, s'il vous plaît réinitialiser aux "
-"valeurs par défaut pour mettre à jour"
-
 msgid "Add module"
 msgstr "Ajouter un module"
 
@@ -390,6 +425,37 @@ msgstr "Module d'exportation"
 
 msgid "Import modules"
 msgstr "Modules d'importation"
+
+msgid "App is not installed in this instance"
+msgstr "L'application n'est pas installée dans ce cas"
+
+msgid "Module does not support this DHIS2 version"
+msgstr "Le module ne supporte pas cette version du DHIS2"
+
+msgid ""
+"There's a new version of this module, please reset to default values to "
+"update"
+msgstr ""
+"Il y a une nouvelle version de ce module, s'il vous plaît réinitialiser aux "
+"valeurs par défaut pour mettre à jour"
+
+msgid "Unable to update module contents"
+msgstr "Impossible de mettre à jour le contenu du module"
+
+msgid "Unable to move item"
+msgstr "Impossible de déplacer l'objet"
+
+msgid "Unable to add step"
+msgstr "Impossible d'ajouter une étape"
+
+msgid "Unable to add page"
+msgstr "Impossible d'ajouter une page"
+
+msgid "Unable to remove step"
+msgstr "Impossible de supprimer l'étape"
+
+msgid "Unable to remove page"
+msgstr "Impossible de supprimer la page"
 
 msgid "Help"
 msgstr "Aide"
@@ -554,19 +620,13 @@ msgid "First load can take a couple of minutes, please wait..."
 msgstr ""
 "Le premier chargement peut prendre quelques minutes, veuillez patienter..."
 
-msgid "Accessible to {{users}} users and {{userGroups}} user groups"
-msgstr ""
-"Accessible aux utilisateurs {{users}} et aux groupes d'utilisateurs "
-"{{userGroups}}."
+#, fuzzy
+msgid "Module"
+msgstr "Modules"
 
-msgid "Accessible to {{users}} users"
-msgstr "Accessible aux {{users}} utilisateurs"
-
-msgid "Accessible to {{userGroups}} user groups"
-msgstr "Accessible aux groupes d'utilisateurs {{userGroups}}"
-
-msgid "Only accessible to system administrators"
-msgstr "Uniquement accessible aux administrateurs du système"
+#, fuzzy
+msgid "Landing Page"
+msgstr "Page d'atterrissage"
 
 msgid "Clean-up unused documents"
 msgstr "Nettoyer les documents inutilisés"
@@ -580,27 +640,6 @@ msgstr "Suppression des documents en suspens"
 msgid "Proceed"
 msgstr "Procédez à"
 
-msgid "Unable to update module contents"
-msgstr "Impossible de mettre à jour le contenu du module"
-
-msgid "Unable to move item"
-msgstr "Impossible de déplacer l'objet"
-
-msgid "Unable to add step"
-msgstr "Impossible d'ajouter une étape"
-
-msgid "Unable to add page"
-msgstr "Impossible d'ajouter une page"
-
-msgid "Unable to remove step"
-msgstr "Impossible de supprimer l'étape"
-
-msgid "Unable to remove page"
-msgstr "Impossible de supprimer la page"
-
-msgid "General Settings"
-msgstr "Paramètres généraux"
-
 msgid "Access to Settings"
 msgstr "Accès aux paramètres"
 
@@ -613,8 +652,9 @@ msgstr "Une liste avec tous les modules existants est visible"
 msgid "The list with all the existing  modules is hidden"
 msgstr "La liste avec tous les modules existants est cachée"
 
-msgid "Customize the landing page"
-msgstr "Personnaliser la page de couverture"
+#, fuzzy
+msgid "Customize landing page selection"
+msgstr "Personnaliser le texte de la page d'accueil"
 
 msgid "Update the logo or content"
 msgstr "Mettre à jour le logo ou le contenu"
@@ -625,5 +665,32 @@ msgstr "Il n'y a pas de documents inutilisés à nettoyer"
 msgid "There are {{total}} documents available to clean"
 msgstr "Il y a {{total}} documents disponibles à nettoyer"
 
+msgid "General Settings"
+msgstr "Paramètres généraux"
+
 msgid "Training modules"
 msgstr "Modules de formation"
+
+#, fuzzy
+msgid "Add Landing Page"
+msgstr "Page d'atterrissage"
+
+#, fuzzy
+msgid "Accessible to {{usersCount}} users and {{userGroupsCount}} user groups"
+msgstr ""
+"Accessible aux utilisateurs {{users}} et aux groupes d'utilisateurs "
+"{{userGroups}}."
+
+#, fuzzy
+msgid "Accessible to {{usersCount}} users"
+msgstr "Accessible aux {{users}} utilisateurs"
+
+#, fuzzy
+msgid "Accessible to {{userGroupsCount}} user groups"
+msgstr "Accessible aux groupes d'utilisateurs {{userGroups}}"
+
+msgid "Only accessible to system administrators"
+msgstr "Uniquement accessible aux administrateurs du système"
+
+#~ msgid "Home page logo"
+#~ msgstr "Logo de la page d'accueil"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Traning App - UI Interface\n"
-"POT-Creation-Date: 2026-01-12T02:42:56.804Z\n"
+"POT-Creation-Date: 2026-02-22T06:14:27.632Z\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -407,9 +407,6 @@ msgstr ""
 msgid "Edit page"
 msgstr "Modifier la page"
 
-msgid "Sharing settings"
-msgstr "Paramètres de partage"
-
 msgid "Delete module"
 msgstr "Supprimer le module"
 
@@ -439,6 +436,10 @@ msgstr ""
 "valeurs par défaut pour mettre à jour"
 
 msgid "Unable to update module contents"
+msgstr "Impossible de mettre à jour le contenu du module"
+
+#, fuzzy
+msgid "Unable to update page permissions"
 msgstr "Impossible de mettre à jour le contenu du module"
 
 msgid "Unable to move item"
@@ -674,7 +675,9 @@ msgid "Add Landing Page"
 msgstr "Ajouter une page d'atterrissage"
 
 msgid "Accessible to {{usersCount}} users and {{userGroupsCount}} user groups"
-msgstr "Accessible à {{usersCount}} utilisateurs et à {{userGroupsCount}} groupes d'utilisateurs"
+msgstr ""
+"Accessible à {{usersCount}} utilisateurs et à {{userGroupsCount}} groupes "
+"d'utilisateurs"
 
 msgid "Accessible to {{usersCount}} users"
 msgstr "Accessible à {{usersCount}} utilisateurs"

--- a/src/data/clients/storage/StorageClient.ts
+++ b/src/data/clients/storage/StorageClient.ts
@@ -28,14 +28,18 @@ export abstract class StorageClient {
     }
 
     public async saveObjectsInCollection<T extends Ref>(key: Namespace, elements: T[]): Promise<void> {
-        const oldData: Ref[] = (await this.getObject(key)) ?? [];
-        const cleanData = oldData.filter(item => !elements.some(element => item.id === element.id));
+        const oldData: T[] = (await this.getObject(key)) ?? [];
 
         // Save base elements directly into collection: model
         const advancedProperties = NamespaceProperties[key] ?? [];
         const baseElements = elements.map(element => _.omit(element, advancedProperties));
 
-        await this.saveObject(key, [...cleanData, ...baseElements]);
+        const updatedData = baseElements.reduce(
+            (acc, baseElement) => this.updateObjectInCollection(acc, baseElement),
+            oldData as Partial<T>[]
+        );
+
+        await this.saveObject(key, updatedData);
 
         // Save advanced properties to its own key: model-id
         if (advancedProperties.length > 0) {
@@ -46,16 +50,22 @@ export abstract class StorageClient {
         }
     }
 
+    private updateObjectInCollection<T extends Ref>(oldData: Partial<T>[], baseElement: Partial<T>): Partial<T>[] {
+        const foundIndex = _.findIndex(oldData, item => item.id === baseElement.id);
+        const arrayIndex = foundIndex === -1 ? oldData.length : foundIndex;
+
+        return [...oldData.slice(0, arrayIndex), baseElement, ...oldData.slice(arrayIndex + 1)];
+    }
+
     public async saveObjectInCollection<T extends Ref>(key: Namespace, element: T): Promise<void> {
         const advancedProperties = NamespaceProperties[key] ?? [];
         const baseElement = _.omit(element, advancedProperties);
 
-        const oldData: Ref[] = (await this.getObject(key)) ?? [];
-        const foundIndex = _.findIndex(oldData, item => item.id === element.id);
-        const arrayIndex = foundIndex === -1 ? oldData.length : foundIndex;
+        const oldData: T[] = (await this.getObject(key)) ?? [];
+        const updatedData = this.updateObjectInCollection(oldData, baseElement);
 
         // Save base element directly into collection: model
-        await this.saveObject(key, [...oldData.slice(0, arrayIndex), baseElement, ...oldData.slice(arrayIndex + 1)]);
+        await this.saveObject(key, updatedData);
 
         // Save advanced properties to its own key: model-id
         if (advancedProperties.length > 0) {

--- a/src/data/clients/storage/StorageClient.ts
+++ b/src/data/clients/storage/StorageClient.ts
@@ -34,9 +34,9 @@ export abstract class StorageClient {
         const advancedProperties = NamespaceProperties[key] ?? [];
         const baseElements = elements.map(element => _.omit(element, advancedProperties));
 
-        const updatedData = baseElements.reduce(
+        const updatedData = baseElements.reduce<Partial<T>[]>(
             (acc, baseElement) => this.updateObjectInCollection(acc, baseElement),
-            oldData as Partial<T>[]
+            oldData
         );
 
         await this.saveObject(key, updatedData);
@@ -61,7 +61,7 @@ export abstract class StorageClient {
         const advancedProperties = NamespaceProperties[key] ?? [];
         const baseElement = _.omit(element, advancedProperties);
 
-        const oldData: T[] = (await this.getObject(key)) ?? [];
+        const oldData = (await this.getObject<T[]>(key)) ?? [];
         const updatedData = this.updateObjectInCollection(oldData, baseElement);
 
         // Save base element directly into collection: model

--- a/src/data/entities/PersistedConfig.ts
+++ b/src/data/entities/PersistedConfig.ts
@@ -1,0 +1,6 @@
+import { CustomText } from "../../domain/entities/CustomText";
+import { Config } from "../../domain/entities/Config";
+
+export type PersistedConfig = Pick<Partial<Config>, "showAllModules" | "logo" | "settingsPermissions"> & {
+    customText?: Partial<CustomText>;
+};

--- a/src/data/entities/User.ts
+++ b/src/data/entities/User.ts
@@ -13,8 +13,12 @@ export interface UserRole extends NamedRef {
     authorities: string[];
 }
 
+type ValidateUserPermissionItem = Pick<BaseMetadata, "publicAccess" | "userAccesses" | "userGroupAccesses"> & {
+    user?: NamedRef;
+};
+
 export const validateUserPermission = (
-    item: Pick<BaseMetadata, "user" | "publicAccess" | "userAccesses" | "userGroupAccesses">,
+    item: ValidateUserPermissionItem,
     permission: "read" | "write",
     currentUser: User
 ) => {
@@ -23,7 +27,7 @@ export const validateUserPermission = (
 
     const isAdmin = isSuperAdmin(currentUser);
 
-    const isUserOwner = user.id === currentUser?.id;
+    const isUserOwner = user?.id === currentUser?.id;
     const isPublic = publicAccess.substring(0, 2).includes(token);
 
     const hasUserAccess = !!_(userAccesses)

--- a/src/data/entities/User.ts
+++ b/src/data/entities/User.ts
@@ -27,7 +27,7 @@ export const validateUserPermission = (
 
     const isAdmin = isSuperAdmin(currentUser);
 
-    const isUserOwner = user?.id === currentUser?.id;
+    const isUserOwner = user?.id && user?.id === currentUser.id;
     const isPublic = publicAccess.substring(0, 2).includes(token);
 
     const hasUserAccess = !!_(userAccesses)

--- a/src/data/repositories/Dhis2ConfigRepository.ts
+++ b/src/data/repositories/Dhis2ConfigRepository.ts
@@ -1,4 +1,4 @@
-import _, { merge } from "lodash";
+import _, { isEmpty, isEqual, merge } from "lodash";
 
 import { ConfigRepository } from "../../domain/repositories/ConfigRepository";
 import { D2Api } from "../../types/d2-api";
@@ -8,8 +8,8 @@ import { Namespaces } from "../clients/storage/Namespaces";
 import { StorageClient } from "../clients/storage/StorageClient";
 import { User } from "../entities/User";
 import { setTranslationValue, TranslatableText } from "../../domain/entities/TranslatableText";
-import { CustomText } from "../../domain/entities/CustomText";
-import { Config, getDefaultConfig, PartialConfig } from "../../domain/entities/Config";
+import { CustomText, getDefaultCustomText } from "../../domain/entities/CustomText";
+import { Config, getDefaultConfig } from "../../domain/entities/Config";
 import { PersistedConfig } from "../entities/PersistedConfig";
 import { Maybe } from "../../types/utils";
 
@@ -50,20 +50,11 @@ export class Dhis2ConfigRepository implements ConfigRepository {
         return getMergedConfig(persistedConfig);
     }
 
-    public async save(update: PartialConfig): Promise<Config> {
-        const config = await this.get();
-        const updatedConfig: PersistedConfig = {
-            ...config,
+    public async save(update: Config): Promise<void> {
+        return this.storageClient.saveObject(Namespaces.CONFIG, {
             ...update,
-            settingsPermissions: {
-                users: update.settingsPermissions?.users ?? config.settingsPermissions?.users ?? [],
-                userGroups: update.settingsPermissions?.userGroups ?? config.settingsPermissions?.userGroups ?? [],
-            },
-        };
-
-        return this.storageClient
-            .saveObject(Namespaces.CONFIG, updatedConfig)
-            .then(() => getMergedConfig(updatedConfig));
+            customText: cleanCustomText(update.customText),
+        });
     }
 
     public async importTranslations(language: string, terms: Record<string, string>): Promise<TranslatableText[]> {
@@ -82,7 +73,15 @@ export class Dhis2ConfigRepository implements ConfigRepository {
                 : undefined,
         };
 
-        const updatedConfig = await this.save({ customText: translatedText });
+        const updatedConfig: Config = {
+            ...config,
+            customText: {
+                rootTitle: translatedText.rootTitle ?? config.customText.rootTitle,
+                rootSubtitle: translatedText.rootSubtitle ?? config.customText.rootSubtitle,
+            },
+        };
+
+        await this.save(updatedConfig);
 
         return this.extractTranslatableText(updatedConfig);
     }
@@ -97,7 +96,7 @@ export class Dhis2ConfigRepository implements ConfigRepository {
     }
 }
 
-function getMergedConfig(config: Maybe<PartialConfig>): Config {
+function getMergedConfig(config: Maybe<PersistedConfig>): Config {
     const defaultConfig = getDefaultConfig();
     const defaultCustomText = defaultConfig.customText;
 
@@ -112,4 +111,25 @@ function getMergedConfig(config: Maybe<PartialConfig>): Config {
         ...config,
         customText: mergedCustomText,
     });
+}
+
+function cleanCustomText(customText: Partial<CustomText>): Partial<CustomText> {
+    const defaultCustomText = getDefaultCustomText();
+
+    return Object.entries(customText).reduce((acc, [key, value]) => {
+        if (isEmpty(value)) return acc;
+
+        const defaultValue = defaultCustomText[key as keyof CustomText];
+        const hasEqualReferenceValue = value.referenceValue === defaultValue?.referenceValue;
+        const hasEmptyOrEqualTranslation =
+            isEmpty(value.translations) ||
+            Object.values(value.translations || {}).every(translation => !translation || translation.trim() === "") ||
+            isEqual(value.translations, defaultValue?.translations);
+
+        if (hasEqualReferenceValue && hasEmptyOrEqualTranslation) {
+            return { ...acc, [key]: undefined };
+        }
+
+        return { ...acc, [key]: value };
+    }, {});
 }

--- a/src/data/repositories/Dhis2ConfigRepository.ts
+++ b/src/data/repositories/Dhis2ConfigRepository.ts
@@ -48,7 +48,7 @@ export class Dhis2ConfigRepository implements ConfigRepository {
     public async get(): Promise<Config> {
         return (
             (await this.storageClient
-                .getObject<PartialConfig>(Namespaces.CONFIG)
+                .getObject<PersistedConfig>(Namespaces.CONFIG)
                 .then(config => getMergedConfig(config))) ?? {}
         );
     }
@@ -65,7 +65,7 @@ export class Dhis2ConfigRepository implements ConfigRepository {
         };
 
         return this.storageClient
-            .saveObject<PersistedConfig>(Namespaces.CONFIG, updatedConfig)
+            .saveObject(Namespaces.CONFIG, updatedConfig)
             .then(() => getMergedConfig(updatedConfig));
     }
 

--- a/src/data/repositories/Dhis2ConfigRepository.ts
+++ b/src/data/repositories/Dhis2ConfigRepository.ts
@@ -1,4 +1,4 @@
-import _, { assign } from "lodash";
+import _, { merge, omitBy } from "lodash";
 
 import { ConfigRepository } from "../../domain/repositories/ConfigRepository";
 import { D2Api } from "../../types/d2-api";
@@ -9,7 +9,9 @@ import { StorageClient } from "../clients/storage/StorageClient";
 import { User } from "../entities/User";
 import { setTranslationValue, TranslatableText } from "../../domain/entities/TranslatableText";
 import { CustomText } from "../../domain/entities/CustomText";
-import { Config, PartialConfig } from "../../domain/entities/Config";
+import { Config, getDefaultConfig, PartialConfig } from "../../domain/entities/Config";
+import { PersistedConfig } from "../entities/PersistedConfig";
+import { Maybe } from "../../types/utils";
 
 export class Dhis2ConfigRepository implements ConfigRepository {
     private storageClient: StorageClient;
@@ -43,17 +45,28 @@ export class Dhis2ConfigRepository implements ConfigRepository {
         };
     }
 
-    public async get(): Promise<Partial<Config>> {
-        return (await this.storageClient.getObject<Partial<Config>>(Namespaces.CONFIG)) ?? {};
+    public async get(): Promise<Config> {
+        return (
+            (await this.storageClient
+                .getObject<PartialConfig>(Namespaces.CONFIG)
+                .then(config => getMergedConfig(config))) ?? {}
+        );
     }
 
-    public async save(update: PartialConfig): Promise<Partial<Config>> {
+    public async save(update: PartialConfig): Promise<Config> {
         const config = await this.get();
-        const updatedConfig: Partial<Config> = assign({}, config, update);
+        const updatedConfig: PersistedConfig = {
+            ...config,
+            ...update,
+            settingsPermissions: {
+                users: update.settingsPermissions?.users ?? config.settingsPermissions?.users ?? [],
+                userGroups: update.settingsPermissions?.userGroups ?? config.settingsPermissions?.userGroups ?? [],
+            },
+        };
 
         return this.storageClient
-            .saveObject<Partial<Config>>(Namespaces.CONFIG, updatedConfig)
-            .then(() => updatedConfig);
+            .saveObject<PersistedConfig>(Namespaces.CONFIG, updatedConfig)
+            .then(() => getMergedConfig(updatedConfig));
     }
 
     public async importTranslations(language: string, terms: Record<string, string>): Promise<TranslatableText[]> {
@@ -85,4 +98,13 @@ export class Dhis2ConfigRepository implements ConfigRepository {
     private extractTranslatableText(config: Partial<Config>): TranslatableText[] {
         return _.compact(_.values(config.customText));
     }
+}
+
+export function getMergedConfig(config: Maybe<PartialConfig>): Config {
+    const cleanCustomText = omitBy(config?.customText, value => value === null);
+    const defaultConfig = getDefaultConfig();
+    return merge({}, defaultConfig, {
+        ...config,
+        customText: cleanCustomText,
+    });
 }

--- a/src/data/repositories/Dhis2ConfigRepository.ts
+++ b/src/data/repositories/Dhis2ConfigRepository.ts
@@ -1,4 +1,4 @@
-import _, { merge, omitBy } from "lodash";
+import _, { merge } from "lodash";
 
 import { ConfigRepository } from "../../domain/repositories/ConfigRepository";
 import { D2Api } from "../../types/d2-api";
@@ -46,11 +46,8 @@ export class Dhis2ConfigRepository implements ConfigRepository {
     }
 
     public async get(): Promise<Config> {
-        return (
-            (await this.storageClient
-                .getObject<PersistedConfig>(Namespaces.CONFIG)
-                .then(config => getMergedConfig(config))) ?? {}
-        );
+        const persistedConfig = await this.storageClient.getObject<PersistedConfig>(Namespaces.CONFIG);
+        return getMergedConfig(persistedConfig);
     }
 
     public async save(update: PartialConfig): Promise<Config> {
@@ -100,11 +97,19 @@ export class Dhis2ConfigRepository implements ConfigRepository {
     }
 }
 
-export function getMergedConfig(config: Maybe<PartialConfig>): Config {
-    const cleanCustomText = omitBy(config?.customText, value => value === null);
+function getMergedConfig(config: Maybe<PartialConfig>): Config {
     const defaultConfig = getDefaultConfig();
-    return merge({}, defaultConfig, {
+    const defaultCustomText = defaultConfig.customText;
+
+    const mergedCustomText = {
+        rootTitle: config?.customText?.rootTitle ?? defaultCustomText.rootTitle,
+        rootSubtitle: config?.customText?.rootSubtitle ?? defaultCustomText.rootSubtitle,
+    };
+
+    const { customText: _, ...defaultConfigWithoutCustomText } = defaultConfig;
+
+    return merge({}, defaultConfigWithoutCustomText, {
         ...config,
-        customText: cleanCustomText,
+        customText: mergedCustomText,
     });
 }

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -53,13 +53,13 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
         }
     }
 
-    private async _list(ids?: string[]): Promise<PersistedLandingPage[]> {
+    private async _list(rootIds?: string[]): Promise<PersistedLandingPage[]> {
         const pages = await this.storageClient.listObjectsInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES);
 
-        if (!ids) {
+        if (!rootIds) {
             return pages;
         } else {
-            const filterByIds = pages.filter(({ id }) => ids.includes(id));
+            const filterByIds = pages.filter(({ id, type }) => rootIds.includes(id) && type === "root");
             return filterByIds.flatMap(page => [page, ...this.getAllDescendants(page.id, pages)]);
         }
     }
@@ -71,12 +71,7 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
     }
 
     public async export(ids: string[]): Promise<void> {
-        const nodes = await this._list(ids);
-        const toExport = _(nodes)
-            .flatMap(node => extractChildrenNodes(buildDomainLandingNode(node, nodes), node.parent))
-            .flatten()
-            .value();
-
+        const toExport = await this._list(ids);
         return this.importExportClient.export(toExport);
     }
 
@@ -94,19 +89,14 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
 
     public async delete(ids: string[]): Promise<void> {
         const nodes = await this._list(ids);
-        const toDelete = _(nodes)
-            .map(node => LandingNodeModel.decode(buildDomainLandingNode(node, nodes)).toMaybe().extract())
-            .compact()
-            .flatMap(node => [node.id, extractChildrenNodes(node, node.parent).map(({ id }) => id)])
-            .flatten()
-            .value();
+        const toDelete = nodes.map(node => node.id);
 
         await this.storageClient.removeObjectsInCollection(Namespaces.LANDING_PAGES, toDelete);
     }
 
     public async extractTranslations(id: string): Promise<TranslatableText[]> {
         const nodes = await this._list([id]);
-        if (!nodes) throw new Error(`Unable to load landing pages`);
+        if (!nodes.length) throw new Error(`Unable to load landing pages`);
         return this.extractTranslatableText(nodes);
     }
 

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -82,7 +82,6 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
 
     public async import(files: File[]): Promise<PersistedLandingPage[]> {
         const items = await this.importExportClient.import<PersistedLandingPage>(files);
-        // TODO: Do not overwrite existing landing page
         await this.storageClient.saveObjectsInCollection(Namespaces.LANDING_PAGES, items);
 
         return items;

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -53,14 +53,17 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
         }
     }
 
-    private async _list(rootIds?: string[]): Promise<PersistedLandingPage[]> {
+    private async _list(ids?: string[]): Promise<PersistedLandingPage[]> {
         const pages = await this.storageClient.listObjectsInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES);
 
-        if (!rootIds) {
+        if (!ids) {
             return pages;
         } else {
-            const filterByIds = pages.filter(({ id, type }) => rootIds.includes(id) && type === "root");
-            return filterByIds.flatMap(page => [page, ...this.getAllDescendants(page.id, pages)]);
+            const filterByIds = pages.filter(({ id }) => ids.includes(id));
+            return _(filterByIds)
+                .flatMap(page => [page, ...this.getAllDescendants(page.id, pages)])
+                .uniqBy(page => page.id)
+                .value();
         }
     }
 

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -68,7 +68,7 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
     public async import(files: File[]): Promise<PersistedLandingPage[]> {
         const items = await this.importExportClient.import<PersistedLandingPage>(files);
         // TODO: Do not overwrite existing landing page
-        await this.storageClient.saveObject(Namespaces.LANDING_PAGES, items);
+        await this.storageClient.saveObjectsInCollection(Namespaces.LANDING_PAGES, items);
 
         return items;
     }
@@ -113,7 +113,10 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
             content: model.content ? setTranslationValue(model.content, language, terms[model.content.key]) : undefined,
         }));
 
-        await this.storageClient.saveObject<PersistedLandingPage[]>(Namespaces.LANDING_PAGES, translatedModels);
+        await this.storageClient.saveObjectsInCollection<PersistedLandingPage>(
+            Namespaces.LANDING_PAGES,
+            translatedModels
+        );
 
         return this.extractTranslatableText(models);
     }

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -122,26 +122,8 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
     }
 
     private async saveDefaultLandingPage(): Promise<PersistedLandingPage> {
-        const root = {
-            id: generateUid(),
-            parent: "none",
-            type: "root" as const,
-            icon: "",
-            order: undefined,
-            name: {
-                key: "root-name",
-                referenceValue: "Main landing page",
-                translations: {},
-            },
-            title: undefined,
-            content: undefined,
-            modules: [],
-            permissions: defaultPermissions,
-            executeOnInit: true,
-        };
-
-        await this.storageClient.saveObjectInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES, root);
-        return root;
+        await this.storageClient.saveObjectInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES, defaultRoot);
+        return defaultRoot;
     }
 }
 
@@ -149,6 +131,23 @@ const defaultPermissions = {
     publicAccess: "r-------",
     userAccesses: [],
     userGroupAccesses: [],
+};
+
+export const defaultRoot: PersistedLandingPage = {
+    id: generateUid(),
+    parent: "none",
+    type: "root" as const,
+    icon: "",
+    order: undefined,
+    name: {
+        key: "root-name",
+        referenceValue: "Main landing page",
+        translations: {},
+    },
+    title: undefined,
+    content: undefined,
+    modules: [],
+    permissions: defaultPermissions,
 };
 
 const buildDomainLandingNode = (root: PersistedLandingPage, items: PersistedLandingPage[]): LandingNode => {

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -67,12 +67,12 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
         return items;
     }
 
-    public async updateChild(node: LandingNode): Promise<void> {
-        const updatedNodes = extractChildrenNodes(node, node.parent);
+    public async update(nodes: LandingNode[]): Promise<void> {
+        const updatedNodes = nodes.map(node => extractChildrenNodes(node, node.parent)).flat();
         await this.storageClient.saveObjectsInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES, updatedNodes);
     }
 
-    public async removeChilds(ids: string[]): Promise<void> {
+    public async delete(ids: string[]): Promise<void> {
         const nodes = await this.storageClient.listObjectsInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES);
         const toDelete = _(nodes)
             .filter(({ id }) => ids.includes(id))
@@ -110,13 +110,6 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
         await this.storageClient.saveObject<PersistedLandingPage[]>(Namespaces.LANDING_PAGES, translatedModels);
 
         return this.extractTranslatableText(models);
-    }
-
-    public async swapOrder(node1: LandingNode, node2: LandingNode) {
-        await this.storageClient.saveObjectsInCollection(Namespaces.LANDING_PAGES, [
-            { ...node1, order: node2.order },
-            { ...node2, order: node1.order },
-        ]);
     }
 
     private async saveDefaultLandingPage(): Promise<PersistedLandingPage> {

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -143,7 +143,7 @@ export const defaultRoot: PersistedLandingPage = {
     order: undefined,
     name: {
         key: "root-name",
-        referenceValue: "Default landing page",
+        referenceValue: "Landing page",
         translations: {},
     },
     title: undefined,

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -55,7 +55,19 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
 
     private async _list(ids?: string[]): Promise<PersistedLandingPage[]> {
         const pages = await this.storageClient.listObjectsInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES);
-        return ids ? pages.filter(({ id }) => ids.includes(id)) : pages;
+
+        if (!ids) {
+            return pages;
+        } else {
+            const filterByIds = pages.filter(({ id }) => ids.includes(id));
+            return filterByIds.flatMap(page => [page, ...this.getAllDescendants(page.id, pages)]);
+        }
+    }
+
+    private getAllDescendants(parentId: string, nodes: PersistedLandingPage[]): PersistedLandingPage[] {
+        return nodes
+            .filter(node => node.parent === parentId)
+            .flatMap(child => [child, ...this.getAllDescendants(child.id, nodes)]);
     }
 
     public async export(ids: string[]): Promise<void> {
@@ -94,11 +106,9 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
     }
 
     public async extractTranslations(id: string): Promise<TranslatableText[]> {
-        const nodes = await this._list();
-        const models = nodes.filter(node => node.id === id || node.parent === id);
-        if (!models.length) throw new Error(`Unable to load landing pages`);
-
-        return this.extractTranslatableText(models);
+        const nodes = await this._list([id]);
+        if (!nodes) throw new Error(`Unable to load landing pages`);
+        return this.extractTranslatableText(nodes);
     }
 
     private extractTranslatableText(models: PersistedLandingPage[]): TranslatableText[] {

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -56,21 +56,27 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
     private async _list(ids?: string[]): Promise<PersistedLandingPage[]> {
         const pages = await this.storageClient.listObjectsInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES);
 
+        const pageParentMap = _(pages)
+            .groupBy(page => page.parent)
+            .value();
+
         if (!ids) {
             return pages;
         } else {
-            const filterByIds = pages.filter(({ id }) => ids.includes(id));
-            return _(filterByIds)
-                .flatMap(page => [page, ...this.getAllDescendants(page.id, pages)])
+            return _(pages)
+                .filter(({ id }) => ids.includes(id))
+                .flatMap(page => [page, ...this.getAllDescendants(page.id, pageParentMap)])
                 .uniqBy(page => page.id)
                 .value();
         }
     }
 
-    private getAllDescendants(parentId: string, nodes: PersistedLandingPage[]): PersistedLandingPage[] {
-        return nodes
-            .filter(node => node.parent === parentId)
-            .flatMap(child => [child, ...this.getAllDescendants(child.id, nodes)]);
+    private getAllDescendants(
+        parentId: string,
+        parentMap: Record<string, PersistedLandingPage[]>
+    ): PersistedLandingPage[] {
+        const children = parentMap[parentId] || [];
+        return children.flatMap(child => [child, ...this.getAllDescendants(child.id, parentMap)]);
     }
 
     public async export(ids: string[]): Promise<void> {

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -13,6 +13,7 @@ import { D2Api } from "../../types/d2-api";
 import { DocumentRepository } from "../../domain/repositories/DocumentRepository";
 import { Either } from "../../domain/entities/Either";
 import { fromPurify } from "../utils/either";
+import { SharedProperties } from "../../domain/entities/Ref";
 
 export class LandingPageDefaultRepository implements LandingPageRepository {
     private storageClient: StorageClient;
@@ -138,7 +139,7 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
     }
 }
 
-const defaultPermissions = {
+const defaultPermissions: SharedProperties = {
     publicAccess: "r-------",
     userAccesses: [],
     userGroupAccesses: [],
@@ -147,7 +148,7 @@ const defaultPermissions = {
 export const defaultRoot: PersistedLandingPage = {
     id: generateUid(),
     parent: "none",
-    type: "root" as const,
+    type: "root",
     icon: "",
     order: undefined,
     name: {

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -30,24 +30,9 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
             const root = persisted?.find(({ parent }) => parent === "none");
 
             if (persisted.length === 0 || !root) {
-                const root = {
-                    id: generateUid(),
-                    parent: "none",
-                    type: "root" as const,
-                    icon: "",
-                    order: undefined,
-                    name: {
-                        key: "root-name",
-                        referenceValue: "Main landing page",
-                        translations: {},
-                    },
-                    title: undefined,
-                    content: undefined,
-                    modules: [],
-                };
-
-                await this.storageClient.saveObjectInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES, root);
-                return [{ ...root, children: [] }];
+                return this.saveDefaultLandingPage()
+                    .then(root => buildDomainLandingNode(root, []))
+                    .then(root => [root]);
             }
 
             const validation = LandingNodeModel.decode(buildDomainLandingNode(root, persisted));
@@ -133,7 +118,36 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
             { ...node2, order: node1.order },
         ]);
     }
+
+    private async saveDefaultLandingPage(): Promise<PersistedLandingPage> {
+        const root = {
+            id: generateUid(),
+            parent: "none",
+            type: "root" as const,
+            icon: "",
+            order: undefined,
+            name: {
+                key: "root-name",
+                referenceValue: "Main landing page",
+                translations: {},
+            },
+            title: undefined,
+            content: undefined,
+            modules: [],
+            permissions: defaultPermissions,
+            executeOnInit: true,
+        };
+
+        await this.storageClient.saveObjectInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES, root);
+        return root;
+    }
 }
+
+const defaultPermissions = {
+    publicAccess: "r-------",
+    userAccesses: [],
+    userGroupAccesses: [],
+};
 
 const buildDomainLandingNode = (root: PersistedLandingPage, items: PersistedLandingPage[]): LandingNode => {
     return {

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -120,7 +120,7 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
             translatedModels
         );
 
-        return this.extractTranslatableText(models);
+        return this.extractTranslatableText(translatedModels);
     }
 
     private async saveDefaultLandingPage(): Promise<PersistedLandingPage> {

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -23,9 +23,7 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
 
     public async list(): Promise<LandingNode[]> {
         try {
-            const persisted = await this.storageClient.listObjectsInCollection<PersistedLandingPage>(
-                Namespaces.LANDING_PAGES
-            );
+            const persisted = await this._list();
 
             const roots = persisted.filter(({ parent }) => parent === "none");
 
@@ -54,10 +52,14 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
         }
     }
 
+    private async _list(ids?: string[]): Promise<PersistedLandingPage[]> {
+        const pages = await this.storageClient.listObjectsInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES);
+        return ids ? pages.filter(({ id }) => ids.includes(id)) : pages;
+    }
+
     public async export(ids: string[]): Promise<void> {
-        const nodes = await this.storageClient.listObjectsInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES);
+        const nodes = await this._list(ids);
         const toExport = _(nodes)
-            .filter(({ id }) => ids.includes(id))
             .flatMap(node => extractChildrenNodes(buildDomainLandingNode(node, nodes), node.parent))
             .flatten()
             .value();
@@ -79,9 +81,8 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
     }
 
     public async delete(ids: string[]): Promise<void> {
-        const nodes = await this.storageClient.listObjectsInCollection<PersistedLandingPage>(Namespaces.LANDING_PAGES);
+        const nodes = await this._list(ids);
         const toDelete = _(nodes)
-            .filter(({ id }) => ids.includes(id))
             .map(node => LandingNodeModel.decode(buildDomainLandingNode(node, nodes)).toMaybe().extract())
             .compact()
             .flatMap(node => [node.id, extractChildrenNodes(node, node.parent).map(({ id }) => id)])
@@ -91,9 +92,10 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
         await this.storageClient.removeObjectsInCollection(Namespaces.LANDING_PAGES, toDelete);
     }
 
-    public async extractTranslations(): Promise<TranslatableText[]> {
-        const models = await this.storageClient.getObject<PersistedLandingPage[]>(Namespaces.LANDING_PAGES);
-        if (!models) throw new Error(`Unable to load landing pages`);
+    public async extractTranslations(id: string): Promise<TranslatableText[]> {
+        const nodes = await this._list();
+        const models = nodes.filter(node => node.id === id || node.parent === id);
+        if (!models.length) throw new Error(`Unable to load landing pages`);
 
         return this.extractTranslatableText(models);
     }

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -27,9 +27,9 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
                 Namespaces.LANDING_PAGES
             );
 
-            const roots = persisted?.filter(({ parent }) => parent === "none");
+            const roots = persisted.filter(({ parent }) => parent === "none");
 
-            if (persisted.length === 0 || !roots?.length) {
+            if (!persisted.length || !roots.length) {
                 return this.saveDefaultLandingPage()
                     .then(root => buildDomainLandingNode(root, []))
                     .then(root => [root]);

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -30,9 +30,8 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
             const roots = persisted.filter(({ parent }) => parent === "none");
 
             if (!persisted.length || !roots.length) {
-                return this.saveDefaultLandingPage()
-                    .then(root => buildDomainLandingNode(root, []))
-                    .then(root => [root]);
+                const defaultRoot = await this.saveDefaultLandingPage();
+                return [buildDomainLandingNode(defaultRoot, [])];
             }
 
             const validations = roots.map(root => {

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -11,6 +11,8 @@ import { PersistedLandingPage } from "../entities/PersistedLandingPage";
 import { generateUid } from "../utils/uid";
 import { D2Api } from "../../types/d2-api";
 import { DocumentRepository } from "../../domain/repositories/DocumentRepository";
+import { Either } from "../../domain/entities/Either";
+import { fromPurify } from "../utils/either";
 
 export class LandingPageDefaultRepository implements LandingPageRepository {
     private storageClient: StorageClient;
@@ -33,19 +35,19 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
                     .then(root => [root]);
             }
 
-            const validations = roots.map(root =>
-                LandingNodeModel.decode(buildDomainLandingNode(root, _.flatten(persisted)))
-            );
-
-            _.forEach(validations, validation => {
-                if (validation.isLeft()) {
-                    console.error(validation.extract());
-
-                    throw new Error(validation.extract());
-                }
+            const validations = roots.map(root => {
+                const node = buildDomainLandingNode(root, _.flatten(persisted));
+                const purifyEither = LandingNodeModel.decode(node);
+                return fromPurify(purifyEither);
             });
 
-            return _.flatten(validations.map(validation => _.compact([validation.toMaybe().extract()])));
+            return Either.sequence(validations).match({
+                success: nodes => nodes,
+                error: error => {
+                    console.error(error);
+                    throw new Error(error);
+                },
+            });
         } catch (error: any) {
             console.error(error);
             return [];

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -27,21 +27,27 @@ export class LandingPageDefaultRepository implements LandingPageRepository {
                 Namespaces.LANDING_PAGES
             );
 
-            const root = persisted?.find(({ parent }) => parent === "none");
+            const roots = persisted?.filter(({ parent }) => parent === "none");
 
-            if (persisted.length === 0 || !root) {
+            if (persisted.length === 0 || !roots?.length) {
                 return this.saveDefaultLandingPage()
                     .then(root => buildDomainLandingNode(root, []))
                     .then(root => [root]);
             }
 
-            const validation = LandingNodeModel.decode(buildDomainLandingNode(root, persisted));
+            const validations = roots.map(root =>
+                LandingNodeModel.decode(buildDomainLandingNode(root, _.flatten(persisted)))
+            );
 
-            if (validation.isLeft()) {
-                throw new Error(validation.extract());
-            }
+            _.forEach(validations, validation => {
+                if (validation.isLeft()) {
+                    console.error(validation.extract());
 
-            return _.compact([validation.toMaybe().extract()]);
+                    throw new Error(validation.extract());
+                }
+            });
+
+            return _.flatten(validations.map(validation => _.compact([validation.toMaybe().extract()])));
         } catch (error: any) {
             console.error(error);
             return [];
@@ -145,6 +151,7 @@ const defaultPermissions = {
 const buildDomainLandingNode = (root: PersistedLandingPage, items: PersistedLandingPage[]): LandingNode => {
     return {
         ...root,
+        permissions: root.permissions ?? defaultPermissions,
         children: _(items)
             .filter(({ parent }) => parent === root.id)
             .sortBy(item => item.order ?? 1000)

--- a/src/data/repositories/LandingPageDefaultRepository.ts
+++ b/src/data/repositories/LandingPageDefaultRepository.ts
@@ -143,7 +143,7 @@ export const defaultRoot: PersistedLandingPage = {
     order: undefined,
     name: {
         key: "root-name",
-        referenceValue: "Main landing page",
+        referenceValue: "Default landing page",
         translations: {},
     },
     title: undefined,

--- a/src/data/repositories/TrainingModuleDefaultRepository.ts
+++ b/src/data/repositories/TrainingModuleDefaultRepository.ts
@@ -226,7 +226,7 @@ export class TrainingModuleDefaultRepository implements TrainingModuleRepository
 
         await this.saveDataStore(translatedModel);
 
-        return this.extractTranslatableText(model);
+        return this.extractTranslatableText(translatedModel);
     }
 
     @cache()

--- a/src/data/utils/either.ts
+++ b/src/data/utils/either.ts
@@ -1,0 +1,9 @@
+import { Either as PurifyEither } from "purify-ts/Either";
+import { Either } from "../../domain/entities/Either";
+
+export function fromPurify<E, D>(purifyEither: PurifyEither<E, D>): Either<E, D> {
+    return purifyEither.caseOf({
+        Right: value => Either.success<E, D>(value),
+        Left: err => Either.error<E>(err),
+    });
+}

--- a/src/domain/entities/Config.ts
+++ b/src/domain/entities/Config.ts
@@ -8,11 +8,6 @@ export type Config = {
     customText: CustomText;
 };
 
-export type PartialConfig = Pick<Partial<Config>, "showAllModules" | "logo"> & {
-    settingsPermissions?: Partial<Permission>;
-    customText?: Partial<CustomText>;
-};
-
 export function getDefaultConfig(): Config {
     return {
         showAllModules: true,

--- a/src/domain/entities/Config.ts
+++ b/src/domain/entities/Config.ts
@@ -1,6 +1,5 @@
 import { Permission } from "./Permission";
 import { CustomText, getDefaultCustomText } from "./CustomText";
-import { RecursivePartial } from "../../types/utils";
 
 export type Config = {
     settingsPermissions: Permission;
@@ -9,13 +8,16 @@ export type Config = {
     customText: CustomText;
 };
 
-export type PartialConfig = RecursivePartial<Config>;
+export type PartialConfig = Pick<Partial<Config>, "showAllModules" | "logo"> & {
+    settingsPermissions?: Partial<Permission>;
+    customText?: Partial<CustomText>;
+};
 
-export function getDefaultConfig({ isDefault }: { isDefault?: boolean } = {}): Config {
+export function getDefaultConfig(): Config {
     return {
         showAllModules: true,
         settingsPermissions: { users: [], userGroups: [] },
-        customText: getDefaultCustomText({ isDefault }),
+        customText: getDefaultCustomText(),
         logo: "",
     };
 }

--- a/src/domain/entities/Config.ts
+++ b/src/domain/entities/Config.ts
@@ -1,6 +1,6 @@
 import { Permission } from "./Permission";
 import { CustomText, getDefaultCustomText } from "./CustomText";
-import { Maybe, RecursivePartial } from "../../types/utils";
+import { NullabelMaybe, RecursivePartial } from "../../types/utils";
 
 export type Config = {
     settingsPermissions: Permission;
@@ -11,7 +11,7 @@ export type Config = {
 
 export type PartialConfig = RecursivePartial<Config>;
 
-export function getDefaultConfig({ isDefault }: { isDefault?: Maybe<boolean> } = {}): Config {
+export function getDefaultConfig({ isDefault }: { isDefault?: NullabelMaybe<boolean> } = {}): Config {
     return {
         showAllModules: true,
         settingsPermissions: { users: [], userGroups: [] },

--- a/src/domain/entities/Config.ts
+++ b/src/domain/entities/Config.ts
@@ -1,6 +1,6 @@
 import { Permission } from "./Permission";
 import { CustomText, getDefaultCustomText } from "./CustomText";
-import { NullabelMaybe, RecursivePartial } from "../../types/utils";
+import { RecursivePartial } from "../../types/utils";
 
 export type Config = {
     settingsPermissions: Permission;
@@ -11,7 +11,7 @@ export type Config = {
 
 export type PartialConfig = RecursivePartial<Config>;
 
-export function getDefaultConfig({ isDefault }: { isDefault?: NullabelMaybe<boolean> } = {}): Config {
+export function getDefaultConfig({ isDefault }: { isDefault?: boolean } = {}): Config {
     return {
         showAllModules: true,
         settingsPermissions: { users: [], userGroups: [] },

--- a/src/domain/entities/CustomText.ts
+++ b/src/domain/entities/CustomText.ts
@@ -13,13 +13,19 @@ export function getDefaultCustomText(): CustomText {
     return {
         rootTitle: {
             key: "root-title",
-            referenceValue: i18n.t("Welcome to training on DHIS2"),
-            translations: {},
+            referenceValue: "Welcome to training on DHIS2",
+            translations: {
+                fr: i18n.t("Welcome to training on DHIS2", { lng: "fr" }),
+                es: i18n.t("Welcome to training on DHIS2", { lng: "es" }),
+            },
         },
         rootSubtitle: {
             key: "root-subtitle",
-            referenceValue: i18n.t("What do you want to learn in DHIS2?"),
-            translations: {},
+            referenceValue: "What do you want to learn in DHIS2?",
+            translations: {
+                fr: i18n.t("What do you want to learn in DHIS2?", { lng: "fr" }),
+                es: i18n.t("What do you want to learn in DHIS2?", { lng: "es" }),
+            },
         },
     };
 }

--- a/src/domain/entities/CustomText.ts
+++ b/src/domain/entities/CustomText.ts
@@ -1,6 +1,5 @@
 import i18n from "../../utils/i18n";
 import { TranslatableText } from "./TranslatableText";
-import { NullabelMaybe } from "../../types/utils";
 
 export type CustomText = {
     rootTitle: TranslatableText;
@@ -10,9 +9,7 @@ export type CustomText = {
 export const CustomTextFields: (keyof CustomText)[] = ["rootTitle", "rootSubtitle"];
 export type CustomTextInfo = { [K in keyof CustomText]: string };
 
-export type DefaultCustomText = CustomText & { isDefault?: NullabelMaybe<boolean> };
-
-export function getDefaultCustomText(): DefaultCustomText {
+export function getDefaultCustomText(): CustomText {
     return {
         rootTitle: {
             key: "root-title",

--- a/src/domain/entities/CustomText.ts
+++ b/src/domain/entities/CustomText.ts
@@ -1,6 +1,6 @@
 import i18n from "../../utils/i18n";
 import { TranslatableText } from "./TranslatableText";
-import { Maybe } from "../../types/utils";
+import { NullabelMaybe } from "../../types/utils";
 
 export type CustomText = {
     rootTitle: TranslatableText;
@@ -10,9 +10,9 @@ export type CustomText = {
 export const CustomTextFields: (keyof CustomText)[] = ["rootTitle", "rootSubtitle"];
 export type CustomTextInfo = { [K in keyof CustomText]: string };
 
-export type DefaultCustomText = CustomText & { isDefault?: Maybe<boolean> };
+export type DefaultCustomText = CustomText & { isDefault?: NullabelMaybe<boolean> };
 
-export function getDefaultCustomText(isDefault: { isDefault?: Maybe<boolean> } = {}): DefaultCustomText {
+export function getDefaultCustomText(isDefault: { isDefault?: NullabelMaybe<boolean> } = {}): DefaultCustomText {
     return {
         rootTitle: {
             key: "root-title",

--- a/src/domain/entities/CustomText.ts
+++ b/src/domain/entities/CustomText.ts
@@ -12,7 +12,7 @@ export type CustomTextInfo = { [K in keyof CustomText]: string };
 
 export type DefaultCustomText = CustomText & { isDefault?: NullabelMaybe<boolean> };
 
-export function getDefaultCustomText(isDefault: { isDefault?: NullabelMaybe<boolean> } = {}): DefaultCustomText {
+export function getDefaultCustomText(): DefaultCustomText {
     return {
         rootTitle: {
             key: "root-title",
@@ -24,6 +24,5 @@ export function getDefaultCustomText(isDefault: { isDefault?: NullabelMaybe<bool
             referenceValue: i18n.t("What do you want to learn in DHIS2?"),
             translations: {},
         },
-        ...isDefault,
     };
 }

--- a/src/domain/entities/Either.ts
+++ b/src/domain/entities/Either.ts
@@ -57,8 +57,7 @@ export class Either<Error, Data> {
 
     static sequence<Error, Data>(eithers: Either<Error, Data>[]): Either<Error, Data[]> {
         return eithers.reduce(
-            (acc: Either<Error, Data[]>, current: Either<Error, Data>) =>
-                Either.map2([acc, current], (accData, currentData) => [...accData, currentData]),
+            (acc, current) => Either.map2([acc, current], (accData, currentData) => [...accData, currentData]),
             Either.success<Error, Data[]>([])
         );
     }

--- a/src/domain/entities/Either.ts
+++ b/src/domain/entities/Either.ts
@@ -54,4 +54,12 @@ export class Either<Error, Data> {
             return either2.map<Res>(data2 => fn(data1, data2));
         });
     }
+
+    static sequence<Error, Data>(eithers: Either<Error, Data>[]): Either<Error, Data[]> {
+        return eithers.reduce(
+            (acc: Either<Error, Data[]>, current: Either<Error, Data>) =>
+                Either.map2([acc, current], (accData, currentData) => [...accData, currentData]),
+            Either.success<Error, Data[]>([])
+        );
+    }
 }

--- a/src/domain/entities/LandingPage.ts
+++ b/src/domain/entities/LandingPage.ts
@@ -3,6 +3,7 @@ import { TranslatableText, TranslatableTextModel } from "./TranslatableText";
 import { SharedProperties, SharedPropertiesModel } from "./Ref";
 import { User, validateUserPermission } from "../../data/entities/User";
 import { generateUid } from "../../data/utils/uid";
+import _ from "lodash";
 
 export const LandingPageNodeTypeModel = Schema.oneOf([
     Schema.exact("root"),
@@ -78,4 +79,8 @@ export function getDefaultLandingNode(props: { type: LandingNodeType; parent: st
             userGroupAccesses: [],
         },
     };
+}
+
+export function flattenNodes(nodes: LandingNode[]): LandingNode[] {
+    return _.flatMap(nodes, row => [row, ...flattenNodes(row.children)]);
 }

--- a/src/domain/entities/LandingPage.ts
+++ b/src/domain/entities/LandingPage.ts
@@ -23,7 +23,6 @@ export interface LandingNode {
     modules: string[];
     children: LandingNode[];
     permissions: SharedProperties;
-    executeOnInit: boolean;
 }
 
 export const LandingNodeModel: Codec<LandingNode> = Schema.object({
@@ -38,7 +37,6 @@ export const LandingNodeModel: Codec<LandingNode> = Schema.object({
     modules: Schema.optionalSafe(Schema.array(Schema.string), []),
     children: Schema.lazy(() => Schema.array(LandingNodeModel)),
     permissions: SharedPropertiesModel,
-    executeOnInit: Schema.optionalSafe(Schema.boolean, true),
 });
 
 export interface OrderedLandingNode extends LandingNode {

--- a/src/domain/entities/LandingPage.ts
+++ b/src/domain/entities/LandingPage.ts
@@ -2,6 +2,7 @@ import { Codec, GetSchemaType, Schema } from "../../utils/codec";
 import { TranslatableText, TranslatableTextModel } from "./TranslatableText";
 import { SharedProperties, SharedPropertiesModel } from "./Ref";
 import { User, validateUserPermission } from "../../data/entities/User";
+import { generateUid } from "../../data/utils/uid";
 
 export const LandingPageNodeTypeModel = Schema.oneOf([
     Schema.exact("root"),
@@ -52,8 +53,29 @@ export const buildOrderedLandingNodes = (nodes: LandingNode[]): OrderedLandingNo
     }));
 };
 
-export function getUserRootLandings(nodes: LandingNode[], currentUser: User) {
+export function getUserRootLandings(nodes: LandingNode[], user: User) {
     return nodes.filter(node => {
-        return node.type === "root" && validateUserPermission(node.permissions, "read", currentUser);
+        return node.type === "root" && validateUserPermission(node.permissions, "read", user);
     });
+}
+
+export function getDefaultLandingNode(props: { type: LandingNodeType; parent: string; order: number }): LandingNode {
+    const { type, parent, order } = props;
+    return {
+        id: generateUid(),
+        type,
+        parent,
+        icon: "",
+        order,
+        name: { key: "", referenceValue: "", translations: {} },
+        title: undefined,
+        content: undefined,
+        children: [],
+        modules: [],
+        permissions: {
+            publicAccess: "r-------",
+            userAccesses: [],
+            userGroupAccesses: [],
+        },
+    };
 }

--- a/src/domain/entities/LandingPage.ts
+++ b/src/domain/entities/LandingPage.ts
@@ -1,6 +1,7 @@
 import { Codec, GetSchemaType, Schema } from "../../utils/codec";
 import { TranslatableText, TranslatableTextModel } from "./TranslatableText";
 import { SharedProperties, SharedPropertiesModel } from "./Ref";
+import { User, validateUserPermission } from "../../data/entities/User";
 
 export const LandingPageNodeTypeModel = Schema.oneOf([
     Schema.exact("root"),
@@ -50,3 +51,9 @@ export const buildOrderedLandingNodes = (nodes: LandingNode[]): OrderedLandingNo
         children: buildOrderedLandingNodes(node.children),
     }));
 };
+
+export function getUserRootLandings(nodes: LandingNode[], currentUser: User) {
+    return nodes.filter(node => {
+        return node.type === "root" && validateUserPermission(node.permissions, "read", currentUser);
+    });
+}

--- a/src/domain/entities/LandingPage.ts
+++ b/src/domain/entities/LandingPage.ts
@@ -1,5 +1,6 @@
 import { Codec, GetSchemaType, Schema } from "../../utils/codec";
 import { TranslatableText, TranslatableTextModel } from "./TranslatableText";
+import { SharedProperties, SharedPropertiesModel } from "./Ref";
 
 export const LandingPageNodeTypeModel = Schema.oneOf([
     Schema.exact("root"),
@@ -21,6 +22,8 @@ export interface LandingNode {
     content: TranslatableText | undefined;
     modules: string[];
     children: LandingNode[];
+    permissions: SharedProperties;
+    executeOnInit: boolean;
 }
 
 export const LandingNodeModel: Codec<LandingNode> = Schema.object({
@@ -34,6 +37,8 @@ export const LandingNodeModel: Codec<LandingNode> = Schema.object({
     content: Schema.optional(TranslatableTextModel),
     modules: Schema.optionalSafe(Schema.array(Schema.string), []),
     children: Schema.lazy(() => Schema.array(LandingNodeModel)),
+    permissions: SharedPropertiesModel,
+    executeOnInit: Schema.optionalSafe(Schema.boolean, true),
 });
 
 export interface OrderedLandingNode extends LandingNode {

--- a/src/domain/entities/TranslatableText.ts
+++ b/src/domain/entities/TranslatableText.ts
@@ -1,6 +1,6 @@
 import { GetSchemaType, Schema } from "../../utils/codec";
 import _ from "lodash";
-import { Maybe } from "../../types/utils";
+import { NullabelMaybe } from "../../types/utils";
 
 export const TranslatableTextModel = Schema.object({
     key: Schema.string,
@@ -22,7 +22,11 @@ export type TranslateMethod = (string: TranslatableText) => string;
 //{lang: {key: translatedText}}
 export type Translations = Record<string, Record<string, string>>;
 
-export function setTranslationValue<T extends TranslatableText>(item: T, language: string, term: Maybe<string>): T {
+export function setTranslationValue<T extends TranslatableText>(
+    item: T,
+    language: string,
+    term: NullabelMaybe<string>
+): T {
     if (term === undefined) {
         return item;
     } else if (language === "en") {

--- a/src/domain/entities/TranslatableText.ts
+++ b/src/domain/entities/TranslatableText.ts
@@ -1,6 +1,6 @@
 import { GetSchemaType, Schema } from "../../utils/codec";
 import _ from "lodash";
-import { NullabelMaybe } from "../../types/utils";
+import { Maybe } from "../../types/utils";
 
 export const TranslatableTextModel = Schema.object({
     key: Schema.string,
@@ -22,11 +22,7 @@ export type TranslateMethod = (string: TranslatableText) => string;
 //{lang: {key: translatedText}}
 export type Translations = Record<string, Record<string, string>>;
 
-export function setTranslationValue<T extends TranslatableText>(
-    item: T,
-    language: string,
-    term: NullabelMaybe<string>
-): T {
+export function setTranslationValue<T extends TranslatableText>(item: T, language: string, term: Maybe<string>): T {
     if (term === undefined) {
         return item;
     } else if (language === "en") {

--- a/src/domain/repositories/ConfigRepository.ts
+++ b/src/domain/repositories/ConfigRepository.ts
@@ -1,9 +1,9 @@
 import { User } from "../../data/entities/User";
-import { Config, PartialConfig } from "../entities/Config";
+import { Config } from "../entities/Config";
 import { TranslableTextRepository } from "./TranslableTextRepository";
 
 export interface ConfigRepository extends TranslableTextRepository {
     getUser(): Promise<User>;
     get(): Promise<Config>;
-    save(update: PartialConfig): Promise<Config>;
+    save(update: Config): Promise<void>;
 }

--- a/src/domain/repositories/ConfigRepository.ts
+++ b/src/domain/repositories/ConfigRepository.ts
@@ -4,6 +4,6 @@ import { TranslableTextRepository } from "./TranslableTextRepository";
 
 export interface ConfigRepository extends TranslableTextRepository {
     getUser(): Promise<User>;
-    get(): Promise<Partial<Config>>;
-    save(update: PartialConfig): Promise<Partial<Config>>;
+    get(): Promise<Config>;
+    save(update: PartialConfig): Promise<Config>;
 }

--- a/src/domain/repositories/LandingPageRepository.ts
+++ b/src/domain/repositories/LandingPageRepository.ts
@@ -4,9 +4,8 @@ import { TranslableTextRepository } from "./TranslableTextRepository";
 
 export interface LandingPageRepository extends TranslableTextRepository {
     list(): Promise<LandingNode[]>;
+    update(nodes: LandingNode[]): Promise<void>;
+    delete(ids: string[]): Promise<void>;
     export(ids: string[]): Promise<void>;
     import(files: File[]): Promise<PersistedLandingPage[]>;
-    updateChild(node: LandingNode): Promise<void>;
-    removeChilds(ids: string[]): Promise<void>;
-    swapOrder(node1: LandingNode, node2: LandingNode): Promise<void>;
 }

--- a/src/domain/usecases/DeleteLandingChildUseCase.ts
+++ b/src/domain/usecases/DeleteLandingChildUseCase.ts
@@ -5,6 +5,6 @@ export class DeleteLandingChildUseCase implements UseCase {
     constructor(private landingPagesRepository: LandingPageRepository) {}
 
     public async execute(ids: string[]): Promise<void> {
-        return this.landingPagesRepository.removeChilds(ids);
+        return this.landingPagesRepository.delete(ids);
     }
 }

--- a/src/domain/usecases/GetConfigUseCase.ts
+++ b/src/domain/usecases/GetConfigUseCase.ts
@@ -1,24 +1,11 @@
-import { isEmpty, merge, omitBy } from "lodash";
-
 import { UseCase } from "../../webapp/CompositionRoot";
 import { ConfigRepository } from "../repositories/ConfigRepository";
-import { Config, getDefaultConfig } from "../entities/Config";
-import { NullabelMaybe } from "../../types/utils";
+import { Config } from "../entities/Config";
 
 export class GetConfigUseCase implements UseCase {
     constructor(private configRepository: ConfigRepository) {}
 
-    public async execute(): Promise<Config> {
-        const config = await this.configRepository.get();
-        return getMergedConfig(config);
+    public execute(): Promise<Config> {
+        return this.configRepository.get();
     }
-}
-
-export function getMergedConfig(config: NullabelMaybe<Partial<Config>>): Config {
-    const cleanCustomText = omitBy(config?.customText, value => value === null);
-    const defaultConfig = getDefaultConfig({ isDefault: isEmpty(cleanCustomText) ? true : undefined });
-    return merge({}, defaultConfig, {
-        ...config,
-        customText: cleanCustomText,
-    });
 }

--- a/src/domain/usecases/GetConfigUseCase.ts
+++ b/src/domain/usecases/GetConfigUseCase.ts
@@ -16,7 +16,7 @@ export class GetConfigUseCase implements UseCase {
 
 export function getMergedConfig(config: NullabelMaybe<Partial<Config>>): Config {
     const cleanCustomText = omitBy(config?.customText, value => value === null);
-    const defaultConfig = getDefaultConfig({ isDefault: isEmpty(cleanCustomText) ? true : null });
+    const defaultConfig = getDefaultConfig({ isDefault: isEmpty(cleanCustomText) ? true : undefined });
     return merge({}, defaultConfig, {
         ...config,
         customText: cleanCustomText,

--- a/src/domain/usecases/GetConfigUseCase.ts
+++ b/src/domain/usecases/GetConfigUseCase.ts
@@ -3,7 +3,7 @@ import { isEmpty, merge, omitBy } from "lodash";
 import { UseCase } from "../../webapp/CompositionRoot";
 import { ConfigRepository } from "../repositories/ConfigRepository";
 import { Config, getDefaultConfig } from "../entities/Config";
-import { Maybe } from "../../types/utils";
+import { NullabelMaybe } from "../../types/utils";
 
 export class GetConfigUseCase implements UseCase {
     constructor(private configRepository: ConfigRepository) {}
@@ -14,7 +14,7 @@ export class GetConfigUseCase implements UseCase {
     }
 }
 
-export function getMergedConfig(config: Maybe<Partial<Config>>): Config {
+export function getMergedConfig(config: NullabelMaybe<Partial<Config>>): Config {
     const cleanCustomText = omitBy(config?.customText, value => value === null);
     const defaultConfig = getDefaultConfig({ isDefault: isEmpty(cleanCustomText) ? true : null });
     return merge({}, defaultConfig, {

--- a/src/domain/usecases/SaveConfigUseCase.ts
+++ b/src/domain/usecases/SaveConfigUseCase.ts
@@ -24,9 +24,21 @@ export class SaveConfigUseCase implements UseCase {
 
         return Object.entries(customText).reduce((acc, [key, value]) => {
             if (isEmpty(value)) return acc;
-            else if (isEqual(value, defaultCustomText[key as keyof CustomText]) || !value.referenceValue)
+
+            const defaultValue = defaultCustomText[key as keyof CustomText];
+            const hasEqualReferenceValue = value.referenceValue === defaultValue?.referenceValue;
+            const hasEmptyOrEqualTranslation =
+                isEmpty(value.translations) ||
+                Object.values(value.translations || {}).every(
+                    translation => !translation || translation.trim() === ""
+                ) ||
+                isEqual(value.translations, defaultValue?.translations);
+
+            if (hasEqualReferenceValue && hasEmptyOrEqualTranslation) {
                 return { ...acc, [key]: undefined };
-            else return { ...acc, [key]: value };
+            }
+
+            return { ...acc, [key]: value };
         }, {});
     }
 }

--- a/src/domain/usecases/SaveConfigUseCase.ts
+++ b/src/domain/usecases/SaveConfigUseCase.ts
@@ -1,44 +1,33 @@
-import { isEmpty, isEqual } from "lodash";
-
 import { UseCase } from "../../webapp/CompositionRoot";
 import { ConfigRepository } from "../repositories/ConfigRepository";
-import { CustomText, getDefaultCustomText } from "../entities/CustomText";
-import { Config, PartialConfig } from "../entities/Config";
+import { CustomText } from "../entities/CustomText";
+import { Config } from "../entities/Config";
+import { Permission } from "../entities/Permission";
+
+export type PartialConfig = Pick<Partial<Config>, "showAllModules" | "logo"> & {
+    settingsPermissions?: Partial<Permission>;
+    customText?: Partial<CustomText>;
+};
 
 export class SaveConfigUseCase implements UseCase {
     constructor(private configRepository: ConfigRepository) {}
 
-    public async execute(config: PartialConfig): Promise<Config> {
-        const { customText, ...rest } = config;
+    public async execute(update: PartialConfig): Promise<void> {
+        const config = await this.configRepository.get();
 
-        const configUpdates = {
-            ...rest,
-            ...(customText && { customText: this.cleanCustomText(customText) }),
+        const updatedConfig: Config = {
+            settingsPermissions: {
+                users: update.settingsPermissions?.users ?? config.settingsPermissions?.users ?? [],
+                userGroups: update.settingsPermissions?.userGroups ?? config.settingsPermissions?.userGroups ?? [],
+            },
+            showAllModules: update.showAllModules ?? config.showAllModules,
+            logo: update.logo ?? config.logo,
+            customText: {
+                rootTitle: update.customText?.rootTitle ?? config.customText.rootTitle,
+                rootSubtitle: update.customText?.rootSubtitle ?? config.customText.rootSubtitle,
+            },
         };
 
-        return await this.configRepository.save(configUpdates);
-    }
-
-    private cleanCustomText(customText: Partial<CustomText>): PartialConfig["customText"] {
-        const defaultCustomText = getDefaultCustomText();
-
-        return Object.entries(customText).reduce((acc, [key, value]) => {
-            if (isEmpty(value)) return acc;
-
-            const defaultValue = defaultCustomText[key as keyof CustomText];
-            const hasEqualReferenceValue = value.referenceValue === defaultValue?.referenceValue;
-            const hasEmptyOrEqualTranslation =
-                isEmpty(value.translations) ||
-                Object.values(value.translations || {}).every(
-                    translation => !translation || translation.trim() === ""
-                ) ||
-                isEqual(value.translations, defaultValue?.translations);
-
-            if (hasEqualReferenceValue && hasEmptyOrEqualTranslation) {
-                return { ...acc, [key]: undefined };
-            }
-
-            return { ...acc, [key]: value };
-        }, {});
+        return await this.configRepository.save(updatedConfig);
     }
 }

--- a/src/domain/usecases/SaveConfigUseCase.ts
+++ b/src/domain/usecases/SaveConfigUseCase.ts
@@ -2,32 +2,24 @@ import { isEmpty, isEqual } from "lodash";
 
 import { UseCase } from "../../webapp/CompositionRoot";
 import { ConfigRepository } from "../repositories/ConfigRepository";
-import { NullabelMaybe } from "../../types/utils";
 import { CustomText, getDefaultCustomText } from "../entities/CustomText";
-import { TranslatableText } from "../entities/TranslatableText";
-import { getMergedConfig } from "./GetConfigUseCase";
-
-export type CustomTextForm = {
-    rootTitle?: NullabelMaybe<TranslatableText>;
-    rootSubtitle?: NullabelMaybe<TranslatableText>;
-};
+import { Config, PartialConfig } from "../entities/Config";
 
 export class SaveConfigUseCase implements UseCase {
     constructor(private configRepository: ConfigRepository) {}
 
-    public async execute(config: Partial<any>): Promise<any> {
+    public async execute(config: PartialConfig): Promise<Config> {
         const { customText, ...rest } = config;
 
         const configUpdates = {
             ...rest,
-            ...(config.customText && { customText: this.cleanCustomText(customText) }),
+            ...(customText && { customText: this.cleanCustomText(customText) }),
         };
 
-        const newConfig = await this.configRepository.save(configUpdates);
-        return getMergedConfig(newConfig);
+        return await this.configRepository.save(configUpdates);
     }
 
-    private cleanCustomText(customText: Partial<CustomText>): CustomTextForm {
+    private cleanCustomText(customText: Partial<CustomText>): PartialConfig["customText"] {
         const defaultCustomText = getDefaultCustomText();
 
         return Object.entries(customText).reduce((acc, [key, value]) => {

--- a/src/domain/usecases/SaveConfigUseCase.ts
+++ b/src/domain/usecases/SaveConfigUseCase.ts
@@ -2,14 +2,14 @@ import { isEmpty, isEqual } from "lodash";
 
 import { UseCase } from "../../webapp/CompositionRoot";
 import { ConfigRepository } from "../repositories/ConfigRepository";
-import { Maybe } from "../../types/utils";
+import { NullabelMaybe } from "../../types/utils";
 import { CustomText, getDefaultCustomText } from "../entities/CustomText";
 import { TranslatableText } from "../entities/TranslatableText";
 import { getMergedConfig } from "./GetConfigUseCase";
 
 export type CustomTextForm = {
-    rootTitle?: Maybe<TranslatableText>;
-    rootSubtitle?: Maybe<TranslatableText>;
+    rootTitle?: NullabelMaybe<TranslatableText>;
+    rootSubtitle?: NullabelMaybe<TranslatableText>;
 };
 
 export class SaveConfigUseCase implements UseCase {

--- a/src/domain/usecases/SwapLandingChildOrderUseCase.ts
+++ b/src/domain/usecases/SwapLandingChildOrderUseCase.ts
@@ -6,6 +6,11 @@ export class SwapLandingChildOrderUseCase implements UseCase {
     constructor(private landingPagesRepository: LandingPageRepository) {}
 
     public async execute(node1: LandingNode, node2: LandingNode): Promise<void> {
-        return this.landingPagesRepository.swapOrder(node1, node2);
+        const updatedNodes = [
+            { ...node1, order: node2.order },
+            { ...node2, order: node1.order },
+        ];
+
+        return this.landingPagesRepository.update(updatedNodes);
     }
 }

--- a/src/domain/usecases/UpdateLandingNodeUseCase.ts
+++ b/src/domain/usecases/UpdateLandingNodeUseCase.ts
@@ -2,10 +2,10 @@ import { UseCase } from "../../webapp/CompositionRoot";
 import { LandingNode } from "../entities/LandingPage";
 import { LandingPageRepository } from "../repositories/LandingPageRepository";
 
-export class UpdateLandingChildUseCase implements UseCase {
+export class UpdateLandingNodeUseCase implements UseCase {
     constructor(private landingPagesRepository: LandingPageRepository) {}
 
     public async execute(node: LandingNode): Promise<void> {
-        return this.landingPagesRepository.updateChild(node);
+        return this.landingPagesRepository.update([node]);
     }
 }

--- a/src/migrations/cli.ts
+++ b/src/migrations/cli.ts
@@ -1,0 +1,20 @@
+import { D2Api } from "../types/d2-api";
+import { MigrationsRunner } from "./index";
+import { getMigrationTasks } from "./tasks";
+
+async function main() {
+    const [baseUrl, auth] = process.argv.slice(2);
+    if (!baseUrl) throw new Error("Usage: index.ts DHIS2_URL [AUTH]");
+
+    const url = auth ? baseUrl.replace("://", `://${auth}@`) : baseUrl;
+    const api = new D2Api({ baseUrl: url });
+    const runner = await MigrationsRunner.init({
+        api,
+        debug: console.debug,
+        migrations: await getMigrationTasks(),
+        dataStoreNamespace: "data-management-app",
+    });
+    runner.execute();
+}
+
+main();

--- a/src/migrations/dataStore.ts
+++ b/src/migrations/dataStore.ts
@@ -1,0 +1,37 @@
+import { D2Api } from "../types/d2-api";
+
+export async function getDataStore<T extends object>(
+    api: D2Api,
+    dataStoreNamespace: string,
+    dataStoreKey: string,
+    defaultValue: T
+): Promise<T> {
+    const dataStore = api.dataStore(dataStoreNamespace);
+    const value = await dataStore.get<T>(dataStoreKey).getData();
+    if (!value) await dataStore.save(dataStoreKey, defaultValue).getData();
+    return value ?? defaultValue;
+}
+
+export async function saveDataStore(
+    api: D2Api,
+    dataStoreNamespace: string,
+    dataStoreKey: string,
+    value: any
+): Promise<void> {
+    const dataStore = api.dataStore(dataStoreNamespace);
+    await dataStore.save(dataStoreKey, value).getData();
+}
+
+export async function deleteDataStore(
+    api: D2Api,
+    dataStoreNamespace: string,
+    dataStoreKey: string
+): Promise<void> {
+    try {
+        await api.delete(`/dataStore/${dataStoreNamespace}/${dataStoreKey}`).getData();
+    } catch (error: any) {
+        if (!error.response || error.response.status !== 404) {
+            throw error;
+        }
+    }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,0 +1,176 @@
+import _ from "lodash";
+import { deleteDataStore, getDataStore, saveDataStore } from "./dataStore";
+import { D2Api } from "../types/d2-api";
+import { promiseMap, zeroPad } from "./utils";
+import { Config, Debug, MigrationWithVersion, RunnerOptions } from "./types";
+import { checkCurrentUserIsSuperadmin } from "./tasks/permissions";
+
+const configKey = "migration";
+
+export class MigrationsRunner {
+    public migrations: MigrationWithVersion[];
+    public debug: Debug;
+    public appVersion: number;
+    private backupPrefix = "backup-";
+    private namespace: string;
+
+    constructor(private api: D2Api, private config: Config, private options: RunnerOptions) {
+        const { debug = _.identity, migrations } = options;
+        this.appVersion = _.max(migrations.map(info => info.version)) || 0;
+        this.debug = debug;
+        this.migrations = this.getMigrationToApply(migrations, config);
+        this.namespace = options.dataStoreNamespace;
+    }
+
+    setDebug(debug: Debug) {
+        const newOptions = { ...this.options, debug };
+        return new MigrationsRunner(this.api, this.config, newOptions);
+    }
+
+    static async init(options: RunnerOptions): Promise<MigrationsRunner> {
+        const { api } = options;
+        const config = await getDataStore<Config>(api, options.dataStoreNamespace, configKey, {
+            version: 0,
+        });
+        return new MigrationsRunner(api, config, options);
+    }
+
+    public async execute(): Promise<void> {
+        // Re-load the runner to make sure we have the latest data as config.
+        const runner = await MigrationsRunner.init(this.options);
+        return runner.migrateFromCurrent();
+    }
+
+    public async migrateFromCurrent(): Promise<void> {
+        const { config, migrations, debug } = this;
+
+        if (_.isEmpty(migrations)) {
+            debug(`No migrations pending to run (current version: ${config.version})`);
+            return;
+        }
+
+        debug(`Migrate: version ${this.instanceVersion} to version ${this.appVersion}`);
+
+        await this.runMigrations(migrations);
+    }
+
+    async runMigrations(migrations: MigrationWithVersion[]): Promise<Config> {
+        const { api, debug, config, namespace } = this;
+
+        const configWithCurrentMigration: Config = {
+            ...config,
+            migration: { version: this.appVersion },
+        };
+        await saveDataStore(api, namespace, configKey, configWithCurrentMigration);
+
+        await checkCurrentUserIsSuperadmin(api, debug);
+
+        for (const migration of migrations) {
+            debug(`Apply migration ${zeroPad(migration.version, 2)} - ${migration.name}`);
+            try {
+                await migration.migrate(api, debug);
+            } catch (error: any) {
+                const errorMsg = `${migration.name}: ${error.message}`;
+                await this.saveConfig({ errorMsg });
+                throw error;
+            }
+        }
+
+        const newConfig = { version: this.appVersion };
+        await saveDataStore(api, namespace, configKey, newConfig);
+        return newConfig;
+    }
+
+    // dataStore backup methods are currently unused, call only if a migration needs it.
+
+    async deleteBackup() {
+        try {
+            const { debug, api, namespace } = this;
+            const backupKeys = await this.getBackupKeys();
+            debug(`Delete backup entries`);
+
+            await promiseMap(backupKeys, async backupKey => {
+                await deleteDataStore(api, namespace, backupKey);
+            });
+        } catch (err) {
+            this.debug(`Error deleting backup (non-fatal)`);
+        }
+    }
+
+    async rollBackExistingBackup() {
+        if (this.config.migration) {
+            await this.rollbackDataStore(new Error("Rollback existing backup"));
+        }
+    }
+
+    async backupDataStore() {
+        const { api, debug, namespace } = this;
+        debug(`Backup data store`);
+        const allKeys = await this.getDataStoreKeys();
+        const keysToBackup = _(allKeys)
+            .reject(key => key.startsWith(this.backupPrefix))
+            .difference([configKey])
+            .compact()
+            .value();
+
+        await promiseMap(keysToBackup, async key => {
+            const value = await getDataStore(api, namespace, key, {});
+            const backupKey = this.backupPrefix + key;
+            await saveDataStore(api, namespace, backupKey, value);
+        });
+    }
+
+    async getDataStoreKeys(): Promise<string[]> {
+        return this.api.dataStore(this.options.dataStoreNamespace).getKeys().getData();
+    }
+
+    async getBackupKeys() {
+        const allKeys = await this.getDataStoreKeys();
+        return allKeys.filter(key => key.startsWith(this.backupPrefix));
+    }
+
+    async rollbackDataStore(error: Error): Promise<Config> {
+        const { api, debug, config, namespace } = this;
+        const errorMsg = error.message || error.toString();
+        const keysToRestore = await this.getBackupKeys();
+
+        if (_.isEmpty(keysToRestore)) return config;
+
+        debug(`Error: ${errorMsg}`);
+        debug("Start rollback");
+
+        await promiseMap(keysToRestore, async backupKey => {
+            const value = await getDataStore(api, namespace, backupKey, {});
+            const key = backupKey.replace(/^backup-/, "");
+            await saveDataStore(api, namespace, key, value);
+            await deleteDataStore(api, namespace, backupKey);
+        });
+
+        return this.saveConfig({ errorMsg });
+    }
+
+    private async saveConfig(options: { errorMsg?: string } = {}) {
+        const { errorMsg } = options;
+        const newConfig: Config = {
+            ...this.config,
+            migration: { version: this.appVersion, error: errorMsg },
+        };
+        await saveDataStore(this.api, this.namespace, configKey, newConfig);
+        return newConfig;
+    }
+
+    getMigrationToApply(allMigrations: MigrationWithVersion[], config: Config) {
+        return _(allMigrations)
+            .filter(info => info.version > config.version)
+            .sortBy(info => info.version)
+            .value();
+    }
+
+    hasPendingMigrations(): boolean {
+        return this.config.version !== this.appVersion;
+    }
+
+    get instanceVersion(): number {
+        return this.config.version;
+    }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,9 +1,10 @@
 import _ from "lodash";
 import { deleteDataStore, getDataStore, saveDataStore } from "./dataStore";
 import { D2Api } from "../types/d2-api";
-import { promiseMap, zeroPad } from "./utils";
+import { zeroPad } from "./utils";
 import { Config, Debug, MigrationWithVersion, RunnerOptions } from "./types";
 import { checkCurrentUserIsSuperadmin } from "./tasks/permissions";
+import { promiseMap } from "../utils/promises";
 
 const configKey = "migration";
 

--- a/src/migrations/tasks/01.support-multiple-landing-move-customizations.ts
+++ b/src/migrations/tasks/01.support-multiple-landing-move-customizations.ts
@@ -26,8 +26,8 @@ async function migrate(api: D2Api, debug: Debug): Promise<void> {
             return {
                 ...node,
                 name: defaultRoot.name,
-                title: defaultCustomText.rootTitle,
-                content: defaultCustomText.rootSubtitle,
+                title: config.customText?.rootTitle ?? defaultCustomText.rootTitle,
+                content: config.customText?.rootSubtitle ?? defaultCustomText.rootSubtitle,
                 icon: config.logo || process.env["REACT_APP_LOGO_PATH"] || "img/logo-eyeseetea.png",
             };
         }
@@ -51,9 +51,9 @@ function saveLandingNodes(api: D2Api, landingNodes: PersistedLandingPage[]): Pro
 function getConfig(api: D2Api): Promise<PersistedConfig> {
     const dataStore = api.dataStore(dataStoreNamespace);
     return dataStore
-        .get<PersistedLandingPage[]>(Namespaces.CONFIG)
+        .get<PersistedConfig>(Namespaces.CONFIG)
         .getData()
-        .then(nodes => nodes || {});
+        .then(config => config || {});
 }
 
 const migration: Migration = { name: "Move customizations to default landing node", migrate };

--- a/src/migrations/tasks/01.support-multiple-landing-move-customizations.ts
+++ b/src/migrations/tasks/01.support-multiple-landing-move-customizations.ts
@@ -4,7 +4,6 @@ import { saveDataStore } from "../dataStore";
 import { dataStoreNamespace, Namespaces } from "../../data/clients/storage/Namespaces";
 import { PersistedLandingPage } from "../../data/entities/PersistedLandingPage";
 import { PersistedConfig } from "../../data/entities/PersistedConfig";
-import { defaultRoot } from "../../data/repositories/LandingPageDefaultRepository";
 import { getDefaultCustomText } from "../../domain/entities/CustomText";
 
 async function migrate(api: D2Api, debug: Debug): Promise<void> {
@@ -22,7 +21,7 @@ async function migrate(api: D2Api, debug: Debug): Promise<void> {
     debug("Updating default landing page title and content with custom text");
     debug("Updating default landing page icon with customized or default logo");
     const updatedLandingNodes = landingNodes.map(node => {
-        if (node.name.referenceValue === defaultRoot.name.referenceValue) {
+        if (node.name.referenceValue === "Main landing page") {
             return {
                 ...node,
                 name: {

--- a/src/migrations/tasks/01.support-multiple-landing-move-customizations.ts
+++ b/src/migrations/tasks/01.support-multiple-landing-move-customizations.ts
@@ -22,7 +22,7 @@ async function migrate(api: D2Api, debug: Debug): Promise<void> {
     debug("Updating default landing page title and content with custom text");
     debug("Updating default landing page icon with customized or default logo");
     const updatedLandingNodes = landingNodes.map(node => {
-        if (node.name.referenceValue === "Main landing page") {
+        if (node.name.referenceValue === "Main landing page" && node.type === "root") {
             return {
                 ...node,
                 name: defaultRoot.name,

--- a/src/migrations/tasks/01.support-multiple-landing-move-customizations.ts
+++ b/src/migrations/tasks/01.support-multiple-landing-move-customizations.ts
@@ -1,0 +1,64 @@
+import { D2Api } from "../../types/d2-api";
+import { Debug, Migration } from "../types";
+import { saveDataStore } from "../dataStore";
+import { dataStoreNamespace, Namespaces } from "../../data/clients/storage/Namespaces";
+import { PersistedLandingPage } from "../../data/entities/PersistedLandingPage";
+import { PersistedConfig } from "../../data/entities/PersistedConfig";
+import { defaultRoot } from "../../data/repositories/LandingPageDefaultRepository";
+import { getDefaultCustomText } from "../../domain/entities/CustomText";
+
+async function migrate(api: D2Api, debug: Debug): Promise<void> {
+    const landingNodes = await getLandingNodes(api);
+
+    if (landingNodes.length === 0) {
+        debug("No landing nodes found, migration not needed.");
+        return;
+    }
+
+    const config = await getConfig(api);
+    const defaultCustomText = getDefaultCustomText();
+
+    debug("Updating main landing page as default landing page");
+    debug("Updating default landing page title and content with custom text");
+    debug("Updating default landing page icon with customized or default logo");
+    const updatedLandingNodes = landingNodes.map(node => {
+        if (node.name.referenceValue === defaultRoot.name.referenceValue) {
+            return {
+                ...node,
+                name: {
+                    ...node.name,
+                    referenceValue: "Default Landing Page",
+                },
+                title: defaultCustomText.rootTitle,
+                content: defaultCustomText.rootSubtitle,
+                icon: config.logo || process.env["REACT_APP_LOGO_PATH"] || "img/logo-eyeseetea.png",
+            };
+        }
+        return node;
+    });
+    await saveLandingNodes(api, updatedLandingNodes);
+}
+
+function getLandingNodes(api: D2Api): Promise<PersistedLandingPage[]> {
+    const dataStore = api.dataStore(dataStoreNamespace);
+    return dataStore
+        .get<PersistedLandingPage[]>(Namespaces.LANDING_PAGES)
+        .getData()
+        .then(nodes => nodes || []);
+}
+
+function saveLandingNodes(api: D2Api, landingNodes: PersistedLandingPage[]): Promise<void> {
+    return saveDataStore(api, dataStoreNamespace, Namespaces.LANDING_PAGES, landingNodes);
+}
+
+function getConfig(api: D2Api): Promise<PersistedConfig> {
+    const dataStore = api.dataStore(dataStoreNamespace);
+    return dataStore
+        .get<PersistedLandingPage[]>(Namespaces.CONFIG)
+        .getData()
+        .then(nodes => nodes || {});
+}
+
+const migration: Migration = { name: "Move customizations to default landing node", migrate };
+
+export default migration;

--- a/src/migrations/tasks/01.support-multiple-landing-move-customizations.ts
+++ b/src/migrations/tasks/01.support-multiple-landing-move-customizations.ts
@@ -5,6 +5,7 @@ import { dataStoreNamespace, Namespaces } from "../../data/clients/storage/Names
 import { PersistedLandingPage } from "../../data/entities/PersistedLandingPage";
 import { PersistedConfig } from "../../data/entities/PersistedConfig";
 import { getDefaultCustomText } from "../../domain/entities/CustomText";
+import { defaultRoot } from "../../data/repositories/LandingPageDefaultRepository";
 
 async function migrate(api: D2Api, debug: Debug): Promise<void> {
     const landingNodes = await getLandingNodes(api);
@@ -24,10 +25,7 @@ async function migrate(api: D2Api, debug: Debug): Promise<void> {
         if (node.name.referenceValue === "Main landing page") {
             return {
                 ...node,
-                name: {
-                    ...node.name,
-                    referenceValue: "Default Landing Page",
-                },
+                name: defaultRoot.name,
                 title: defaultCustomText.rootTitle,
                 content: defaultCustomText.rootSubtitle,
                 icon: config.logo || process.env["REACT_APP_LOGO_PATH"] || "img/logo-eyeseetea.png",

--- a/src/migrations/tasks/index.ts
+++ b/src/migrations/tasks/index.ts
@@ -1,0 +1,5 @@
+import { MigrationTasks, migration } from "../types";
+
+export async function getMigrationTasks(): Promise<MigrationTasks> {
+    return [migration(1, (await import("./01.support-multiple-landing-move-customizations")).default)];
+}

--- a/src/migrations/tasks/permissions.ts
+++ b/src/migrations/tasks/permissions.ts
@@ -1,0 +1,10 @@
+import { D2Api } from "../../types/d2-api";
+import { Debug } from "../types";
+
+export async function checkCurrentUserIsSuperadmin(api: D2Api, debug: Debug) {
+    debug("Check that current user is superadmin");
+    const currentUser = await api.currentUser.get({ fields: { authorities: true } }).getData();
+
+    if (!currentUser.authorities.includes("ALL"))
+        throw new Error("Only a user with authority ALL can run this migration");
+}

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -1,0 +1,31 @@
+import { D2Api } from "../types/d2-api";
+
+export interface Config {
+    version: number;
+    migration?: { version: number; error?: string };
+}
+
+export type Debug = (message: string) => void;
+
+export interface MigrationWithVersion {
+    version: number;
+    migrate: MigrationFn;
+    name: string;
+}
+
+export type Migration = Omit<MigrationWithVersion, "version">;
+
+export type MigrationFn = (api: D2Api, debug: Debug) => Promise<void>;
+
+export interface RunnerOptions {
+    api: D2Api;
+    debug?: Debug;
+    dataStoreNamespace: string;
+    migrations: MigrationWithVersion[];
+}
+
+export type MigrationTasks = MigrationWithVersion[];
+
+export function migration(version: number, migration: Migration): MigrationWithVersion {
+    return { version, ...migration };
+}

--- a/src/migrations/utils.ts
+++ b/src/migrations/utils.ts
@@ -1,0 +1,19 @@
+export function promiseMap<T, S>(inputValues: T[], mapper: (value: T) => Promise<S>): Promise<S[]> {
+    const reducer = (acc$: Promise<S[]>, inputValue: T): Promise<S[]> =>
+        acc$.then((acc: S[]) =>
+            mapper(inputValue).then(result => {
+                acc.push(result);
+                return acc;
+            })
+        );
+    return inputValues.reduce(reducer, Promise.resolve([]));
+}
+
+export function zeroPad(num: number, places: number) {
+    const zero = places - num.toString().length + 1;
+    return Array(+(zero > 0 && zero)).join("0") + num;
+}
+
+export function enumerate<T>(xs: T[]): Array<[number, T]> {
+    return xs.map((x, idx) => [idx, x]);
+}

--- a/src/migrations/utils.ts
+++ b/src/migrations/utils.ts
@@ -1,19 +1,4 @@
-export function promiseMap<T, S>(inputValues: T[], mapper: (value: T) => Promise<S>): Promise<S[]> {
-    const reducer = (acc$: Promise<S[]>, inputValue: T): Promise<S[]> =>
-        acc$.then((acc: S[]) =>
-            mapper(inputValue).then(result => {
-                acc.push(result);
-                return acc;
-            })
-        );
-    return inputValues.reduce(reducer, Promise.resolve([]));
-}
-
 export function zeroPad(num: number, places: number) {
     const zero = places - num.toString().length + 1;
     return Array(+(zero > 0 && zero)).join("0") + num;
-}
-
-export function enumerate<T>(xs: T[]): Array<[number, T]> {
-    return xs.map((x, idx) => [idx, x]);
 }

--- a/src/tutorial-module/useTutorial.ts
+++ b/src/tutorial-module/useTutorial.ts
@@ -1,10 +1,10 @@
 import React from "react";
 import { TrainingModule } from "../domain/entities/TrainingModule";
-import { Maybe } from "../types/utils";
+import { NullabelMaybe } from "../types/utils";
 
 export type ModuleStepType = "welcome" | "contents" | "steps" | "final" | "summary";
 
-export function useUpdateModuleStep(props: { module: Maybe<TrainingModule> }) {
+export function useUpdateModuleStep(props: { module: NullabelMaybe<TrainingModule> }) {
     const { module } = props;
     const [moduleStep, setModuleStep] = React.useState<ModuleStepType>("welcome");
     const [tutorialProgress, setTutorialProgress] = React.useState({ step: 1, content: 1 });

--- a/src/tutorial-module/useTutorial.ts
+++ b/src/tutorial-module/useTutorial.ts
@@ -1,10 +1,10 @@
 import React from "react";
 import { TrainingModule } from "../domain/entities/TrainingModule";
-import { NullabelMaybe } from "../types/utils";
+import { Maybe } from "../types/utils";
 
 export type ModuleStepType = "welcome" | "contents" | "steps" | "final" | "summary";
 
-export function useUpdateModuleStep(props: { module: NullabelMaybe<TrainingModule> }) {
+export function useUpdateModuleStep(props: { module: Maybe<TrainingModule> }) {
     const { module } = props;
     const [moduleStep, setModuleStep] = React.useState<ModuleStepType>("welcome");
     const [tutorialProgress, setTutorialProgress] = React.useState({ step: 1, content: 1 });

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,6 +1,6 @@
 import { JSXElementConstructor, ComponentProps } from "react";
 
-export type Maybe<T> = T | undefined | null;
+export type Maybe<T> = T | undefined;
 
 export type Dictionary<T> = Record<string, T>;
 

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -2,6 +2,8 @@ import { JSXElementConstructor, ComponentProps } from "react";
 
 export type Maybe<T> = T | undefined;
 
+export type NullabelMaybe<T> = Maybe<T> | null;
+
 export type Dictionary<T> = Record<string, T>;
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -2,8 +2,6 @@ import { JSXElementConstructor, ComponentProps } from "react";
 
 export type Maybe<T> = T | undefined;
 
-export type NullabelMaybe<T> = Maybe<T> | null;
-
 export type Dictionary<T> = Record<string, T>;
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/src/webapp/CompositionRoot.tsx
+++ b/src/webapp/CompositionRoot.tsx
@@ -22,7 +22,7 @@ import { ListModulesUseCase } from "../domain/usecases/ListModulesUseCase";
 import { ResetModuleDefaultValueUseCase } from "../domain/usecases/ResetModuleDefaultValueUseCase";
 import { SearchUsersUseCase } from "../domain/usecases/SearchUsersUseCase";
 import { SwapModuleOrderUseCase } from "../domain/usecases/SwapModuleOrderUseCase";
-import { UpdateLandingChildUseCase } from "../domain/usecases/UpdateLandingChildUseCase";
+import { UpdateLandingNodeUseCase } from "../domain/usecases/UpdateLandingNodeUseCase";
 import { UpdateModuleUseCase } from "../domain/usecases/UpdateModuleUseCase";
 import { UpdateUserProgressUseCase } from "../domain/usecases/UpdateUserProgressUseCase";
 import { UploadFileUseCase } from "../domain/usecases/UploadFileUseCase";
@@ -62,7 +62,7 @@ export function getCompositionRoot(api: D2Api) {
             }),
             landings: getExecute({
                 list: new ListLandingChildrenUseCase(landingPageRepository),
-                update: new UpdateLandingChildUseCase(landingPageRepository),
+                update: new UpdateLandingNodeUseCase(landingPageRepository),
                 delete: new DeleteLandingChildUseCase(landingPageRepository),
                 export: new ExportLandingPagesUseCase(landingPageRepository),
                 import: new ImportLandingPagesUseCase(landingPageRepository),

--- a/src/webapp/components/customize-settings-dialog/CustomizeSettingsDialog.tsx
+++ b/src/webapp/components/customize-settings-dialog/CustomizeSettingsDialog.tsx
@@ -18,7 +18,7 @@ export type CustomizeSettingsSaveForm = {
 };
 
 export type CustomSettingsDialogProps = CustomizeSettingsSaveForm & {
-    onSave: (data: Partial<CustomizeSettingsSaveForm>) => void;
+    onSave: (data: Partial<CustomizeSettingsSaveForm>) => Promise<void>;
     onClose: () => void;
 };
 

--- a/src/webapp/components/customize-settings-dialog/CustomizeSettingsDialog.tsx
+++ b/src/webapp/components/customize-settings-dialog/CustomizeSettingsDialog.tsx
@@ -76,6 +76,7 @@ export const CustomizeSettingsDialog: React.FC<CustomSettingsDialogProps> = prop
 
     return (
         <ConfirmationDialog
+            title={i18n.t("Customize main landing page")}
             isOpen={true}
             fullWidth={true}
             onSave={save}
@@ -84,17 +85,16 @@ export const CustomizeSettingsDialog: React.FC<CustomSettingsDialogProps> = prop
             disableSave={disableSave}
         >
             <ImportTranslationDialog type="custom-text" ref={translationImportRef} onSave={handleTranslationUpload} />
-            <Typography variant="h6">{i18n.t("Home page logo")}</Typography>
+            <Typography variant="h6">{i18n.t("Logo")}</Typography>
             <Box marginBottom={3}>
                 <IconUpload>
                     <IconContainer>
-                        <img src={logoVal} alt={i18n.t("Home page logo")} />
+                        <img src={logoVal} alt={i18n.t("Logo")} />
                     </IconContainer>
                     <FileInput type="file" onChange={handleFileUpload} />
                 </IconUpload>
             </Box>
             <Box display="flex" alignItems="center">
-                <Typography variant="h6">{i18n.t("Customize landing page text")}</Typography>
                 {!isCustomTextDefault && (
                     <>
                         <IconButton onClick={handleClickMenu}>

--- a/src/webapp/components/customize-settings-dialog/CustomizeSettingsDialog.tsx
+++ b/src/webapp/components/customize-settings-dialog/CustomizeSettingsDialog.tsx
@@ -5,28 +5,21 @@ import Typography from "@material-ui/core/Typography";
 
 import { ConfirmationDialog } from "@eyeseetea/d2-ui-components";
 import i18n from "../../../utils/i18n";
-import { CustomText, CustomTextInfo } from "../../../domain/entities/CustomText";
+import { CustomTextInfo } from "../../../domain/entities/CustomText";
 import { ImportTranslationDialog } from "../import-translation-dialog/ImportTranslationDialog";
 import { useCustomizeSettingsDialog } from "./useCustomizeSettingsDialog";
 import { TitleMenu } from "./TitleMenu";
 
-export type CustomizeSettingsSaveForm = {
-    customText: Partial<CustomText>;
-    logo: string;
-};
-
-export type CustomSettingsDialogProps = CustomizeSettingsSaveForm & {
-    onSave: (data: Partial<CustomizeSettingsSaveForm>) => Promise<void>;
+export type CustomSettingsDialogProps = {
     onClose: () => void;
 };
 
 export const CustomizeSettingsDialog: React.FC<CustomSettingsDialogProps> = props => {
-    const { onSave, customText, logo, onClose } = props;
+    const { onClose } = props;
     const {
         logoVal,
         customTextVal,
         customTextKeys,
-        isCustomTextDefault,
         disableSave,
         save,
         onChangeField,
@@ -35,17 +28,11 @@ export const CustomizeSettingsDialog: React.FC<CustomSettingsDialogProps> = prop
         handleTranslationUpload,
         exportTranslations,
         importTranslations,
-    } = useCustomizeSettingsDialog({ logo, customText, onSave });
+    } = useCustomizeSettingsDialog(props);
 
     return (
         <ConfirmationDialog
-            title={
-                <TitleMenu
-                    hideMenu={isCustomTextDefault}
-                    exportTranslations={exportTranslations}
-                    importTranslations={importTranslations}
-                />
-            }
+            title={<TitleMenu exportTranslations={exportTranslations} importTranslations={importTranslations} />}
             isOpen={true}
             fullWidth={true}
             onSave={save}

--- a/src/webapp/components/customize-settings-dialog/CustomizeSettingsDialog.tsx
+++ b/src/webapp/components/customize-settings-dialog/CustomizeSettingsDialog.tsx
@@ -1,8 +1,5 @@
-import MoreVertIcon from "@material-ui/icons/MoreVert";
-import MenuItem from "@material-ui/core/MenuItem";
-import Menu from "@material-ui/core/Menu";
-import { Box, Icon, IconButton, TextField } from "@material-ui/core";
-import React, { useCallback, useMemo, useState } from "react";
+import { Box, TextField } from "@material-ui/core";
+import React from "react";
 import styled from "styled-components";
 import Typography from "@material-ui/core/Typography";
 
@@ -11,6 +8,7 @@ import i18n from "../../../utils/i18n";
 import { CustomText, CustomTextInfo } from "../../../domain/entities/CustomText";
 import { ImportTranslationDialog } from "../import-translation-dialog/ImportTranslationDialog";
 import { useCustomizeSettingsDialog } from "./useCustomizeSettingsDialog";
+import { TitleMenu } from "./TitleMenu";
 
 export type CustomizeSettingsSaveForm = {
     customText: Partial<CustomText>;
@@ -39,44 +37,15 @@ export const CustomizeSettingsDialog: React.FC<CustomSettingsDialogProps> = prop
         importTranslations,
     } = useCustomizeSettingsDialog({ logo, customText, onSave });
 
-    const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
-    const menuOpen = Boolean(menuAnchor);
-
-    const handleClickMenu = useCallback((event: React.MouseEvent<HTMLElement>) => {
-        setMenuAnchor(event.currentTarget);
-    }, []);
-
-    const handleCloseMenu = useCallback(() => {
-        setMenuAnchor(null);
-    }, []);
-
-    const menuAction = useMemo(
-        () => [
-            {
-                key: "export",
-                icon: <Icon>cloud_download</Icon>,
-                text: i18n.t("Export JSON translations"),
-                onClick: async () => {
-                    await exportTranslations();
-                    handleCloseMenu();
-                },
-            },
-            {
-                key: "import",
-                icon: <Icon>translate</Icon>,
-                text: i18n.t("Import JSON translations"),
-                onClick: () => {
-                    importTranslations();
-                    handleCloseMenu();
-                },
-            },
-        ],
-        [exportTranslations, importTranslations, handleCloseMenu]
-    );
-
     return (
         <ConfirmationDialog
-            title={i18n.t("Customize main landing page")}
+            title={
+                <TitleMenu
+                    hideMenu={isCustomTextDefault}
+                    exportTranslations={exportTranslations}
+                    importTranslations={importTranslations}
+                />
+            }
             isOpen={true}
             fullWidth={true}
             onSave={save}
@@ -93,23 +62,6 @@ export const CustomizeSettingsDialog: React.FC<CustomSettingsDialogProps> = prop
                     </IconContainer>
                     <FileInput type="file" onChange={handleFileUpload} />
                 </IconUpload>
-            </Box>
-            <Box display="flex" alignItems="center">
-                {!isCustomTextDefault && (
-                    <>
-                        <IconButton onClick={handleClickMenu}>
-                            <MoreVertIcon />
-                        </IconButton>
-                        <Menu anchorEl={menuAnchor} open={menuOpen} onClose={handleCloseMenu}>
-                            {menuAction.map(action => (
-                                <StyledMenuItem key={action.key} onClick={action.onClick}>
-                                    {action.icon}
-                                    {action.text}
-                                </StyledMenuItem>
-                            ))}
-                        </Menu>
-                    </>
-                )}
             </Box>
 
             {customTextKeys.map(key => (
@@ -152,10 +104,6 @@ const IconUpload = styled.div`
 
 const FileInput = styled.input`
     outline: none;
-`;
-
-const StyledMenuItem = styled(MenuItem)`
-    gap: 1.25em;
 `;
 
 const customTextLabel: CustomTextInfo = {

--- a/src/webapp/components/customize-settings-dialog/CustomizeSettingsDialog.tsx
+++ b/src/webapp/components/customize-settings-dialog/CustomizeSettingsDialog.tsx
@@ -27,7 +27,6 @@ export const CustomizeSettingsDialog: React.FC<CustomSettingsDialogProps> = prop
     const {
         logoVal,
         customTextVal,
-        defaultCustomText,
         customTextKeys,
         isCustomTextDefault,
         disableSave,
@@ -118,7 +117,6 @@ export const CustomizeSettingsDialog: React.FC<CustomSettingsDialogProps> = prop
                     <TextField
                         fullWidth={true}
                         label={customTextLabel[key]}
-                        placeholder={i18n.t(defaultCustomText[key]?.referenceValue)}
                         value={customTextVal[key] ? customTextVal[key]?.referenceValue : ""}
                         InputLabelProps={inputProps}
                         onChange={onChangeField(key)}

--- a/src/webapp/components/customize-settings-dialog/TitleMenu.tsx
+++ b/src/webapp/components/customize-settings-dialog/TitleMenu.tsx
@@ -8,13 +8,12 @@ import MenuItem from "@material-ui/core/MenuItem";
 import i18n from "../../../utils/i18n";
 
 type TitleMenuProps = {
-    hideMenu: boolean;
     importTranslations: () => void;
     exportTranslations: () => Promise<void>;
 };
 
 export const TitleMenu: React.FC<TitleMenuProps> = props => {
-    const { hideMenu, exportTranslations, importTranslations } = props;
+    const { exportTranslations, importTranslations } = props;
 
     const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
     const menuOpen = Boolean(menuAnchor);
@@ -54,21 +53,18 @@ export const TitleMenu: React.FC<TitleMenuProps> = props => {
     return (
         <Box display="flex" alignItems="center">
             {i18n.t("Customize main landing page")}
-            {!hideMenu && (
-                <>
-                    <IconButton onClick={handleClickMenu}>
-                        <MoreVertIcon />
-                    </IconButton>
-                    <Menu anchorEl={menuAnchor} open={menuOpen} onClose={handleCloseMenu}>
-                        {menuAction.map(action => (
-                            <StyledMenuItem key={action.key} onClick={action.onClick}>
-                                {action.icon}
-                                {action.text}
-                            </StyledMenuItem>
-                        ))}
-                    </Menu>
-                </>
-            )}
+
+            <IconButton onClick={handleClickMenu}>
+                <MoreVertIcon />
+            </IconButton>
+            <Menu anchorEl={menuAnchor} open={menuOpen} onClose={handleCloseMenu}>
+                {menuAction.map(action => (
+                    <StyledMenuItem key={action.key} onClick={action.onClick}>
+                        {action.icon}
+                        {action.text}
+                    </StyledMenuItem>
+                ))}
+            </Menu>
         </Box>
     );
 };

--- a/src/webapp/components/customize-settings-dialog/TitleMenu.tsx
+++ b/src/webapp/components/customize-settings-dialog/TitleMenu.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { Box, Icon, IconButton } from "@material-ui/core";
-import i18n from "../../../utils/i18n";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 import Menu from "@material-ui/core/Menu";
 import styled from "styled-components";
 import MenuItem from "@material-ui/core/MenuItem";
+
+import i18n from "../../../utils/i18n";
 
 type TitleMenuProps = {
     hideMenu: boolean;

--- a/src/webapp/components/customize-settings-dialog/TitleMenu.tsx
+++ b/src/webapp/components/customize-settings-dialog/TitleMenu.tsx
@@ -1,0 +1,77 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { Box, Icon, IconButton } from "@material-ui/core";
+import i18n from "../../../utils/i18n";
+import MoreVertIcon from "@material-ui/icons/MoreVert";
+import Menu from "@material-ui/core/Menu";
+import styled from "styled-components";
+import MenuItem from "@material-ui/core/MenuItem";
+
+type TitleMenuProps = {
+    hideMenu: boolean;
+    importTranslations: () => void;
+    exportTranslations: () => Promise<void>;
+};
+
+export const TitleMenu: React.FC<TitleMenuProps> = props => {
+    const { hideMenu, exportTranslations, importTranslations } = props;
+
+    const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+    const menuOpen = Boolean(menuAnchor);
+
+    const handleClickMenu = useCallback((event: React.MouseEvent<HTMLElement>) => {
+        setMenuAnchor(event.currentTarget);
+    }, []);
+
+    const handleCloseMenu = useCallback(() => {
+        setMenuAnchor(null);
+    }, []);
+
+    const menuAction = useMemo(
+        () => [
+            {
+                key: "export",
+                icon: <Icon>cloud_download</Icon>,
+                text: i18n.t("Export JSON translations"),
+                onClick: async () => {
+                    await exportTranslations();
+                    handleCloseMenu();
+                },
+            },
+            {
+                key: "import",
+                icon: <Icon>translate</Icon>,
+                text: i18n.t("Import JSON translations"),
+                onClick: () => {
+                    importTranslations();
+                    handleCloseMenu();
+                },
+            },
+        ],
+        [exportTranslations, importTranslations, handleCloseMenu]
+    );
+
+    return (
+        <Box display="flex" alignItems="center">
+            {i18n.t("Customize main landing page")}
+            {!hideMenu && (
+                <>
+                    <IconButton onClick={handleClickMenu}>
+                        <MoreVertIcon />
+                    </IconButton>
+                    <Menu anchorEl={menuAnchor} open={menuOpen} onClose={handleCloseMenu}>
+                        {menuAction.map(action => (
+                            <StyledMenuItem key={action.key} onClick={action.onClick}>
+                                {action.icon}
+                                {action.text}
+                            </StyledMenuItem>
+                        ))}
+                    </Menu>
+                </>
+            )}
+        </Box>
+    );
+};
+
+const StyledMenuItem = styled(MenuItem)`
+    gap: 1.25em;
+`;

--- a/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
+++ b/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
@@ -15,7 +15,7 @@ export const useCustomizeSettingsDialog = ({
     customText,
     onSave,
 }: Omit<CustomSettingsDialogProps, "onClose">) => {
-    const { appConfig } = useAppConfigContext();
+    const { appConfig, reload } = useAppConfigContext();
     const appCustomText = appConfig.customText;
     const defaultCustomText = getDefaultCustomText();
     const { exportTranslation, importTranslation } = useImportExportTranslation();
@@ -59,6 +59,7 @@ export const useCustomizeSettingsDialog = ({
     const handleTranslationUpload = useCallback(
         async (_key: string | undefined, lang: string, terms: Record<string, string>) => {
             await importTranslation(() => usecases.config.importTranslations(lang, terms));
+            await reload();
         },
         [usecases, importTranslation]
     );

--- a/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
+++ b/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
@@ -58,7 +58,7 @@ export const useCustomizeSettingsDialog = (props: CustomSettingsDialogProps) => 
         async (_key: string | undefined, lang: string, terms: Record<string, string>) => {
             await importTranslation(() => usecases.config.importTranslations(lang, terms));
             await reloadConfig().then(config => {
-                setCustomText(prev => updateCustomTextState(prev, config.customText));
+                setCustomText(prev => updateStateTranslations(prev, config.customText));
             });
         },
         [usecases, importTranslation, reloadConfig]
@@ -89,7 +89,7 @@ export const useCustomizeSettingsDialog = (props: CustomSettingsDialogProps) => 
     };
 };
 
-function updateCustomTextItem(prevItem: TranslatableText, currentItem: TranslatableText): TranslatableText {
+function updateItemTranslation(prevItem: TranslatableText, currentItem: TranslatableText): TranslatableText {
     return currentItem.translations
         ? {
               ...prevItem,
@@ -98,10 +98,10 @@ function updateCustomTextItem(prevItem: TranslatableText, currentItem: Translata
         : prevItem;
 }
 
-function updateCustomTextState(prev: CustomText, current: CustomText): CustomText {
+function updateStateTranslations(prev: CustomText, current: CustomText): CustomText {
     return {
         ...prev,
-        rootTitle: updateCustomTextItem(prev.rootTitle, current.rootTitle),
-        rootSubtitle: updateCustomTextItem(prev.rootSubtitle, current.rootSubtitle),
+        rootTitle: updateItemTranslation(prev.rootTitle, current.rootTitle),
+        rootSubtitle: updateItemTranslation(prev.rootSubtitle, current.rootSubtitle),
     };
 }

--- a/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
+++ b/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { useState, useCallback, useRef, ChangeEvent } from "react";
 
-import { CustomText, CustomTextFields, getDefaultCustomText } from "../../../domain/entities/CustomText";
+import { CustomText, CustomTextFields } from "../../../domain/entities/CustomText";
 import { ImportTranslationRef } from "../import-translation-dialog/ImportTranslationDialog";
 import { CustomSettingsDialogProps } from "./CustomizeSettingsDialog";
 import { useAppContext } from "../../contexts/app-context";
@@ -9,34 +9,32 @@ import { useAppConfigContext } from "../../contexts/AppConfigProvider";
 import { useImportExportTranslation } from "../../hooks/useImportExportTranslation";
 import { useLoading } from "@eyeseetea/d2-ui-components";
 import i18n from "../../../utils/i18n";
+import { TranslatableText } from "../../../domain/entities/TranslatableText";
 
-export const useCustomizeSettingsDialog = ({
-    logo,
-    customText,
-    onSave,
-}: Omit<CustomSettingsDialogProps, "onClose">) => {
-    const { appConfig, reload } = useAppConfigContext();
-    const appCustomText = appConfig.customText;
-    const defaultCustomText = getDefaultCustomText();
+export const useCustomizeSettingsDialog = (props: CustomSettingsDialogProps) => {
+    const { onClose } = props;
+    const { appConfig, logoInfo, reloadConfig, save: saveConfig } = useAppConfigContext();
+    const logo = logoInfo.logoPath;
+
     const { exportTranslation, importTranslation } = useImportExportTranslation();
     const { usecases } = useAppContext();
     const loading = useLoading();
 
     const [logoVal, setLogo] = useState<string>(logo);
-    const [customTextVal, setCustomText] = useState<Partial<CustomText>>(customText);
+    const [customTextVal, setCustomText] = useState(appConfig.customText);
     const translationImportRef = useRef<ImportTranslationRef>(null);
 
     const logoHasChanges = logoVal !== logo;
-    const isCustomTextDefault = _.isEqual(customText, defaultCustomText);
-    const customTextHasChanges = !_.isEqual(customTextVal, appCustomText);
+    const customTextHasChanges = !_.isEqual(customTextVal, appConfig.customText);
     const disableSave = !logoHasChanges && !customTextHasChanges;
 
-    const save = useCallback(() => {
-        onSave({
-            ...(customTextHasChanges ? { customText: { ...customText, ...customTextVal } } : {}),
+    const save = useCallback(async () => {
+        await saveConfig({
+            ...(customTextHasChanges ? { customText: { ...appConfig.customText, ...customTextVal } } : {}),
             ...(logoHasChanges ? { logo: logoVal } : {}),
         });
-    }, [onSave, customText, customTextVal, customTextHasChanges, logoVal, logoHasChanges]);
+        onClose();
+    }, [saveConfig, appConfig.customText, customTextVal, customTextHasChanges, logoVal, logoHasChanges]);
 
     const onChangeField = (field: keyof CustomText) => {
         return (event: React.ChangeEvent<{ value: string }>) => {
@@ -59,9 +57,11 @@ export const useCustomizeSettingsDialog = ({
     const handleTranslationUpload = useCallback(
         async (_key: string | undefined, lang: string, terms: Record<string, string>) => {
             await importTranslation(() => usecases.config.importTranslations(lang, terms));
-            await reload();
+            await reloadConfig().then(config => {
+                setCustomText(prev => updateCustomTextState(prev, config.customText));
+            });
         },
-        [usecases, importTranslation, reload]
+        [usecases, importTranslation, reloadConfig, appConfig]
     );
 
     const exportTranslations = useCallback(async () => {
@@ -78,7 +78,6 @@ export const useCustomizeSettingsDialog = ({
         logoVal,
         customTextVal,
         customTextKeys: CustomTextFields,
-        isCustomTextDefault,
         disableSave,
         save,
         onChangeField,
@@ -89,3 +88,20 @@ export const useCustomizeSettingsDialog = ({
         handleTranslationUpload,
     };
 };
+
+function updateCustomTextItem(prevItem: TranslatableText, currentItem: TranslatableText): TranslatableText {
+    return currentItem.translations
+        ? {
+              ...prevItem,
+              translations: currentItem.translations,
+          }
+        : prevItem;
+}
+
+function updateCustomTextState(prev: CustomText, current: CustomText): CustomText {
+    return {
+        ...prev,
+        rootTitle: updateCustomTextItem(prev.rootTitle, current.rootTitle),
+        rootSubtitle: updateCustomTextItem(prev.rootSubtitle, current.rootSubtitle),
+    };
+}

--- a/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
+++ b/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
@@ -61,7 +61,7 @@ export const useCustomizeSettingsDialog = ({
             await importTranslation(() => usecases.config.importTranslations(lang, terms));
             await reload();
         },
-        [usecases, importTranslation]
+        [usecases, importTranslation, reload]
     );
 
     const exportTranslations = useCallback(async () => {

--- a/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
+++ b/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
@@ -17,7 +17,7 @@ export const useCustomizeSettingsDialog = ({
 }: Omit<CustomSettingsDialogProps, "onClose">) => {
     const { appConfig } = useAppConfigContext();
     const appCustomText = appConfig.customText;
-    const defaultCustomText = getDefaultCustomText({ isDefault: true });
+    const defaultCustomText = getDefaultCustomText();
     const { exportTranslation, importTranslation } = useImportExportTranslation();
     const { usecases } = useAppContext();
     const loading = useLoading();
@@ -76,7 +76,6 @@ export const useCustomizeSettingsDialog = ({
     return {
         logoVal,
         customTextVal,
-        defaultCustomText,
         customTextKeys: CustomTextFields,
         isCustomTextDefault,
         disableSave,

--- a/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
+++ b/src/webapp/components/customize-settings-dialog/useCustomizeSettingsDialog.ts
@@ -34,7 +34,7 @@ export const useCustomizeSettingsDialog = (props: CustomSettingsDialogProps) => 
             ...(logoHasChanges ? { logo: logoVal } : {}),
         });
         onClose();
-    }, [saveConfig, appConfig.customText, customTextVal, customTextHasChanges, logoVal, logoHasChanges]);
+    }, [saveConfig, appConfig.customText, customTextVal, customTextHasChanges, logoVal, logoHasChanges, onClose]);
 
     const onChangeField = (field: keyof CustomText) => {
         return (event: React.ChangeEvent<{ value: string }>) => {
@@ -61,7 +61,7 @@ export const useCustomizeSettingsDialog = (props: CustomSettingsDialogProps) => 
                 setCustomText(prev => updateCustomTextState(prev, config.customText));
             });
         },
-        [usecases, importTranslation, reloadConfig, appConfig]
+        [usecases, importTranslation, reloadConfig]
     );
 
     const exportTranslations = useCallback(async () => {

--- a/src/webapp/components/home/MainLandingPage.tsx
+++ b/src/webapp/components/home/MainLandingPage.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { LandingNode } from "../../../domain/entities/LandingPage";
+import styled from "styled-components";
+import { useAppConfigContext } from "../../contexts/AppConfigProvider";
+import { ModalContent, ModalParagraph, ModalTitle } from "../modal";
+import { useAppContext } from "../../contexts/app-context";
+import { Cardboard } from "../card-board/Cardboard";
+import { BigCard } from "../card-board/BigCard";
+import i18n from "../../../utils/i18n";
+
+type TrainingAreaProps = {
+    landingNodes: LandingNode[];
+    openPage: (page: LandingNode) => void;
+};
+
+export const MainLandingPage: React.FC<TrainingAreaProps> = (props: TrainingAreaProps) => {
+    const { landingNodes, openPage } = props;
+    const { translate } = useAppContext();
+    const { appConfig, logoInfo } = useAppConfigContext();
+    const { logoPath, logoText } = logoInfo;
+
+    return (
+        <React.Fragment>
+            <LogoContainer>
+                <img src={logoPath} alt={logoText} />
+            </LogoContainer>
+            <ModalTitle bold={true} big={true}>
+                {translate(appConfig.customText.rootTitle)}
+            </ModalTitle>
+            <ModalContent>
+                <ModalParagraph size={28} align={"left"}>
+                    {translate(appConfig.customText.rootSubtitle)}
+                </ModalParagraph>
+
+                <Cardboard rowSize={3}>
+                    {landingNodes.map((item, idx) => (
+                        <BigCard
+                            key={`card-${idx}`}
+                            label={translate(item.name)}
+                            onClick={() => openPage(item)}
+                            icon={
+                                item.icon ? (
+                                    <img
+                                        src={item.icon}
+                                        alt={i18n.t("Icon for {{name}}", { name: translate(item.name) })}
+                                    />
+                                ) : undefined
+                            }
+                        />
+                    ))}
+                </Cardboard>
+            </ModalContent>
+        </React.Fragment>
+    );
+};
+
+const LogoContainer = styled.div`
+    margin-top: 15px;
+
+    img {
+        margin: 0 30px;
+        user-drag: none;
+        max-height: 100px;
+    }
+`;

--- a/src/webapp/components/home/MainLandingPage.tsx
+++ b/src/webapp/components/home/MainLandingPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { LandingNode } from "../../../domain/entities/LandingPage";
 import styled from "styled-components";
+
+import { LandingNode } from "../../../domain/entities/LandingPage";
 import { useAppConfigContext } from "../../contexts/AppConfigProvider";
 import { ModalContent, ModalParagraph, ModalTitle } from "../modal";
 import { useAppContext } from "../../contexts/app-context";

--- a/src/webapp/components/home/Root.tsx
+++ b/src/webapp/components/home/Root.tsx
@@ -15,13 +15,15 @@ export const Root: React.FC<HomePageProps> = props => {
 
     return (
         <React.Fragment>
-            <LogoContainer>
-                <img src={currentPage.icon} alt={`Page icon`} />
-            </LogoContainer>
+            {currentPage.icon && (
+                <LogoContainer>
+                    <img src={currentPage.icon} alt={`Page icon`} />
+                </LogoContainer>
+            )}
+
             <ModalTitle bold={true} big={true}>
                 {translate(currentPage.title ?? currentPage.name)}
             </ModalTitle>
-
             <ModalContent>
                 <ModalParagraph size={28} align={"left"}>
                     {currentPage.content ? <MarkdownContents source={translate(currentPage.content)} /> : null}

--- a/src/webapp/components/home/Root.tsx
+++ b/src/webapp/components/home/Root.tsx
@@ -4,30 +4,27 @@ import React from "react";
 import styled from "styled-components";
 
 import { useAppContext } from "../../contexts/app-context";
-import { useAppConfigContext } from "../../contexts/AppConfigProvider";
 import { ModalContent, ModalParagraph, ModalTitle } from "../modal";
-import { HomePageProps } from "./HomePageContent";
+import { HomePageProps, MarkdownContents } from "./HomePageContent";
 import { Modules } from "./Modules";
 import i18n from "../../../utils/i18n";
 
 export const Root: React.FC<HomePageProps> = props => {
     const { currentPage, loadModule, isRoot, openPage } = props;
     const { translate } = useAppContext();
-    const { appConfig, logoInfo } = useAppConfigContext();
-    const { logoPath, logoText } = logoInfo;
 
     return (
         <React.Fragment>
             <LogoContainer>
-                <img src={logoPath} alt={logoText} />
+                <img src={currentPage.icon} alt={`Page icon`} />
             </LogoContainer>
             <ModalTitle bold={true} big={true}>
-                {translate(appConfig.customText.rootTitle)}
+                {translate(currentPage.title ?? currentPage.name)}
             </ModalTitle>
 
             <ModalContent>
                 <ModalParagraph size={28} align={"left"}>
-                    {translate(appConfig.customText.rootSubtitle)}
+                    {currentPage.content ? <MarkdownContents source={translate(currentPage.content)} /> : null}
                 </ModalParagraph>
 
                 <Cardboard rowSize={3} key={`group-${currentPage.id}`}>

--- a/src/webapp/components/landing-page-edit-dialog/LandingPageEditDialog.tsx
+++ b/src/webapp/components/landing-page-edit-dialog/LandingPageEditDialog.tsx
@@ -7,35 +7,12 @@ import {
 import { TextField } from "@material-ui/core";
 import React, { ChangeEvent, useCallback, useMemo, useState } from "react";
 import styled from "styled-components";
-import { generateUid } from "../../../data/utils/uid";
-import { LandingNode, LandingNodeType } from "../../../domain/entities/LandingPage";
+import { getDefaultLandingNode, LandingNode, LandingNodeType } from "../../../domain/entities/LandingPage";
 import i18n from "../../../utils/i18n";
 import { useAppContext } from "../../contexts/app-context";
 import { MarkdownEditor } from "../markdown-editor/MarkdownEditor";
 import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
 import { ModalBody } from "../modal";
-
-const buildDefaultNode = (props: { type: LandingNodeType; parent: string; order: number; executeOnInit: boolean }) => {
-    const { type, parent, order, executeOnInit } = props;
-    return {
-        id: generateUid(),
-        type,
-        parent,
-        icon: "",
-        order,
-        name: { key: "", referenceValue: "", translations: {} },
-        title: undefined,
-        content: undefined,
-        children: [],
-        modules: [],
-        permissions: {
-            publicAccess: "r-------",
-            userAccesses: [],
-            userGroupAccesses: [],
-        },
-        executeOnInit: executeOnInit,
-    };
-};
 
 export const LandingPageEditDialog: React.FC<LandingPageEditDialogProps> = props => {
     const { type, parent, order, initialNode, onSave } = props;
@@ -45,9 +22,7 @@ export const LandingPageEditDialog: React.FC<LandingPageEditDialogProps> = props
     const { modules, translate, usecases } = useAppContext();
     const snackbar = useSnackbar();
 
-    const [value, setValue] = useState<LandingNode>(
-        initialNode ?? buildDefaultNode({ type, parent, order, executeOnInit: true })
-    );
+    const [value, setValue] = useState<LandingNode>(initialNode ?? getDefaultLandingNode({ type, parent, order }));
 
     const items = useMemo(
         () =>

--- a/src/webapp/components/landing-page-edit-dialog/LandingPageEditDialog.tsx
+++ b/src/webapp/components/landing-page-edit-dialog/LandingPageEditDialog.tsx
@@ -15,7 +15,8 @@ import { MarkdownEditor } from "../markdown-editor/MarkdownEditor";
 import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
 import { ModalBody } from "../modal";
 
-const buildDefaultNode = (type: LandingNodeType, parent: string, order: number) => {
+const buildDefaultNode = (props: { type: LandingNodeType; parent: string; order: number; executeOnInit: boolean }) => {
+    const { type, parent, order, executeOnInit } = props;
     return {
         id: generateUid(),
         type,
@@ -27,6 +28,12 @@ const buildDefaultNode = (type: LandingNodeType, parent: string, order: number) 
         content: undefined,
         children: [],
         modules: [],
+        permissions: {
+            publicAccess: "r-------",
+            userAccesses: [],
+            userGroupAccesses: [],
+        },
+        executeOnInit: executeOnInit,
     };
 };
 
@@ -36,7 +43,9 @@ export const LandingPageEditDialog: React.FC<LandingPageEditDialogProps> = props
     const { modules, translate, usecases } = useAppContext();
     const snackbar = useSnackbar();
 
-    const [value, setValue] = useState<LandingNode>(initialNode ?? buildDefaultNode(type, parent, order));
+    const [value, setValue] = useState<LandingNode>(
+        initialNode ?? buildDefaultNode({ type, parent, order, executeOnInit: true })
+    );
 
     const items = useMemo(
         () =>

--- a/src/webapp/components/landing-page-edit-dialog/LandingPageEditDialog.tsx
+++ b/src/webapp/components/landing-page-edit-dialog/LandingPageEditDialog.tsx
@@ -117,59 +117,57 @@ export const LandingPageEditDialog: React.FC<LandingPageEditDialogProps> = props
                     onChange={onChangeField("name")}
                 />
             </Row>
+            <Row>
+                <TextField
+                    fullWidth={true}
+                    label={i18n.t("Title")}
+                    value={value.title?.referenceValue ?? ""}
+                    onChange={onChangeField("title")}
+                />
+            </Row>
+
+            <Row>
+                <h3>{i18n.t("Icon")}</h3>
+
+                <IconUpload>
+                    {value.icon ? (
+                        <IconContainer>
+                            <img src={value.icon} alt={`Page icon`} />
+                        </IconContainer>
+                    ) : null}
+
+                    <FileInput type="file" onChange={handleFileUpload} />
+                </IconUpload>
+            </Row>
+
             {!isRoot && (
-                <>
-                    <Row>
-                        <TextField
-                            fullWidth={true}
-                            label={i18n.t("Title")}
-                            value={value.title?.referenceValue ?? ""}
-                            onChange={onChangeField("title")}
-                        />
-                    </Row>
+                <Row>
+                    <h3>{i18n.t("Modules")}</h3>
 
-                    <Row>
-                        <h3>{i18n.t("Icon")}</h3>
-
-                        <IconUpload>
-                            {value.icon ? (
-                                <IconContainer>
-                                    <img src={value.icon} alt={`Page icon`} />
-                                </IconContainer>
-                            ) : null}
-
-                            <FileInput type="file" onChange={handleFileUpload} />
-                        </IconUpload>
-                    </Row>
-
-                    <Row>
-                        <h3>{i18n.t("Modules")}</h3>
-
-                        <ModuleSelector
-                            label={i18n.t("Modules assigned")}
-                            items={items}
-                            values={value.modules}
-                            onChange={modules => setValue(landing => ({ ...landing, modules }))}
-                        />
-                    </Row>
-
-                    <Row>
-                        <h3>{i18n.t("Contents")}</h3>
-
-                        <MarkdownEditor
-                            value={value.content?.referenceValue ?? ""}
-                            onChange={referenceValue =>
-                                setValue(landing => ({
-                                    ...landing,
-                                    content: { key: `${value.id}-content`, referenceValue, translations: {} },
-                                }))
-                            }
-                            markdownPreview={markdown => <StepPreview value={markdown} />}
-                            onUpload={(data, file) => usecases.document.uploadFile(data, file.name)}
-                        />
-                    </Row>
-                </>
+                    <ModuleSelector
+                        label={i18n.t("Modules assigned")}
+                        items={items}
+                        values={value.modules}
+                        onChange={modules => setValue(landing => ({ ...landing, modules }))}
+                    />
+                </Row>
             )}
+
+            <Row>
+                <h3>{i18n.t("Contents")}</h3>
+
+                <MarkdownEditor
+                    value={value.content?.referenceValue ?? ""}
+                    onChange={referenceValue =>
+                        setValue(landing => ({
+                            ...landing,
+                            content: { key: `${value.id}-content`, referenceValue, translations: {} },
+                        }))
+                    }
+                    markdownPreview={markdown => <StepPreview value={markdown} />}
+                    onUpload={(data, file) => usecases.document.uploadFile(data, file.name)}
+                />
+            </Row>
         </ConfirmationDialog>
     );
 };

--- a/src/webapp/components/landing-page-edit-dialog/LandingPageEditDialog.tsx
+++ b/src/webapp/components/landing-page-edit-dialog/LandingPageEditDialog.tsx
@@ -40,6 +40,8 @@ const buildDefaultNode = (props: { type: LandingNodeType; parent: string; order:
 export const LandingPageEditDialog: React.FC<LandingPageEditDialogProps> = props => {
     const { type, parent, order, initialNode, onSave } = props;
 
+    const isRoot = type === "root";
+
     const { modules, translate, usecases } = useAppContext();
     const snackbar = useSnackbar();
 
@@ -115,56 +117,59 @@ export const LandingPageEditDialog: React.FC<LandingPageEditDialogProps> = props
                     onChange={onChangeField("name")}
                 />
             </Row>
+            {!isRoot && (
+                <>
+                    <Row>
+                        <TextField
+                            fullWidth={true}
+                            label={i18n.t("Title")}
+                            value={value.title?.referenceValue ?? ""}
+                            onChange={onChangeField("title")}
+                        />
+                    </Row>
 
-            <Row>
-                <TextField
-                    fullWidth={true}
-                    label={i18n.t("Title")}
-                    value={value.title?.referenceValue ?? ""}
-                    onChange={onChangeField("title")}
-                />
-            </Row>
+                    <Row>
+                        <h3>{i18n.t("Icon")}</h3>
 
-            <Row>
-                <h3>{i18n.t("Icon")}</h3>
+                        <IconUpload>
+                            {value.icon ? (
+                                <IconContainer>
+                                    <img src={value.icon} alt={`Page icon`} />
+                                </IconContainer>
+                            ) : null}
 
-                <IconUpload>
-                    {value.icon ? (
-                        <IconContainer>
-                            <img src={value.icon} alt={`Page icon`} />
-                        </IconContainer>
-                    ) : null}
+                            <FileInput type="file" onChange={handleFileUpload} />
+                        </IconUpload>
+                    </Row>
 
-                    <FileInput type="file" onChange={handleFileUpload} />
-                </IconUpload>
-            </Row>
+                    <Row>
+                        <h3>{i18n.t("Modules")}</h3>
 
-            <Row>
-                <h3>{i18n.t("Modules")}</h3>
+                        <ModuleSelector
+                            label={i18n.t("Modules assigned")}
+                            items={items}
+                            values={value.modules}
+                            onChange={modules => setValue(landing => ({ ...landing, modules }))}
+                        />
+                    </Row>
 
-                <ModuleSelector
-                    label={i18n.t("Modules assigned")}
-                    items={items}
-                    values={value.modules}
-                    onChange={modules => setValue(landing => ({ ...landing, modules }))}
-                />
-            </Row>
+                    <Row>
+                        <h3>{i18n.t("Contents")}</h3>
 
-            <Row>
-                <h3>{i18n.t("Contents")}</h3>
-
-                <MarkdownEditor
-                    value={value.content?.referenceValue ?? ""}
-                    onChange={referenceValue =>
-                        setValue(landing => ({
-                            ...landing,
-                            content: { key: `${value.id}-content`, referenceValue, translations: {} },
-                        }))
-                    }
-                    markdownPreview={markdown => <StepPreview value={markdown} />}
-                    onUpload={(data, file) => usecases.document.uploadFile(data, file.name)}
-                />
-            </Row>
+                        <MarkdownEditor
+                            value={value.content?.referenceValue ?? ""}
+                            onChange={referenceValue =>
+                                setValue(landing => ({
+                                    ...landing,
+                                    content: { key: `${value.id}-content`, referenceValue, translations: {} },
+                                }))
+                            }
+                            markdownPreview={markdown => <StepPreview value={markdown} />}
+                            onUpload={(data, file) => usecases.document.uploadFile(data, file.name)}
+                        />
+                    </Row>
+                </>
+            )}
         </ConfirmationDialog>
     );
 };

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -26,6 +26,10 @@ import { ImportTranslationDialog, ImportTranslationRef } from "../import-transla
 import { useImportExportTranslation } from "../../hooks/useImportExportTranslation";
 import { StepPreview } from "../step-preview/StepPreview";
 import { Maybe } from "../../../types/utils";
+import { CompositionRoot } from "../../CompositionRoot";
+import { LoadingState } from "@eyeseetea/d2-ui-components/loading/types";
+import { Translations } from "../../../domain/entities/TranslatableText";
+import { PermissionHandlerProps, PermissionsDialog } from "../permissions-dialog/PermissionsDialog";
 
 type LandingNodeAction = (ids: string[]) => void;
 
@@ -43,14 +47,15 @@ export const LandingPageListTable: React.FC<LandingPageListTableProps> = props =
 
     const { usecases, reload } = useAppContext();
     const { exportTranslation, importTranslation } = useImportExportTranslation();
-
     const loading = useLoading();
     const snackbar = useSnackbar();
 
     const landingImportRef = useRef<DropzoneRef>(null);
     const translationImportRef = useRef<ImportTranslationRef>(null);
-
     const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
+    const [permissionLandingNodeId, setPermissionLandingNodeId] = useState<string>();
+
+    const closePermissionsDialog = useCallback(() => setPermissionLandingNodeId(undefined), []);
 
     const openImportDialog = useCallback(async () => {
         landingImportRef.current?.openDialog();
@@ -95,177 +100,74 @@ export const LandingPageListTable: React.FC<LandingPageListTableProps> = props =
         [usecases.landings, importTranslation]
     );
 
-    const move = useCallback(
-        async (ids: string[], nodes: LandingNode[], change: "up" | "down") => {
-            const orderChange = change === "up" ? -1 : 1;
-            const allNodes = flattenRows(nodes);
-
-            const firstNode = allNodes.find(({ id }) => id === ids[0]);
-            if (firstNode?.order === undefined) return;
-
-            const parent = allNodes.find(({ id }) => id === firstNode?.parent);
-            const secondNode = parent?.children[firstNode?.order + orderChange];
-            if (secondNode?.order === undefined) return;
-
-            await usecases.landings.swapOrder(firstNode, secondNode);
-            await reload();
-        },
-        [reload, usecases]
-    );
-
-    const columns: TableColumn<LandingNode>[] = useMemo(
-        () => [
-            {
-                name: "type",
-                text: "Type",
-                sortable: false,
-                getValue: item => getTypeName(item.type),
-            },
-            {
-                name: "name",
-                text: "Name",
-                getValue: item => item.name?.referenceValue ?? "-",
-            },
-            {
-                name: "title",
-                text: "Title",
-                getValue: item => item.title?.referenceValue ?? "-",
-            },
-            {
-                name: "content",
-                text: "Content",
-                getValue: item => (item.content ? <StepPreview value={item.content.referenceValue} /> : "-"),
-            },
-            {
-                name: "icon",
-                text: "Icon",
-                getValue: item =>
-                    item.icon ? <ItemIcon src={item.icon} alt={`Icon for ${item.name.referenceValue}`} /> : "-",
-            },
-        ],
-        []
-    );
-
     const actions: TableAction<LandingNode>[] = useMemo(
-        () => [
-            {
-                name: "add-section",
-                text: i18n.t("Add section"),
-                icon: <Icon>add</Icon>,
-                onClick: onAddSection,
-                isActive: nodes => _.every(nodes, item => item.type === "root"),
-            },
-            {
-                name: "add-sub-section",
-                text: i18n.t("Add sub-section"),
-                icon: <Icon>add</Icon>,
-                onClick: onAddSubSection,
-                isActive: nodes => _.every(nodes, item => item.type === "section"),
-            },
-            {
-                name: "add-category",
-                text: i18n.t("Add category"),
-                icon: <Icon>add</Icon>,
-                onClick: onAddCategory,
-                isActive: nodes => _.every(nodes, item => item.type === "sub-section" || item.type === "category"),
-            },
-            {
-                name: "edit",
-                text: i18n.t("Edit"),
-                icon: <Icon>edit</Icon>,
-                onClick: onEditLandingNode,
-                isActive: nodes => _.every(nodes, item => item.type !== "root"),
-            },
-            {
-                name: "remove",
-                text: i18n.t("Delete"),
-                icon: <Icon>delete</Icon>,
-                multiple: true,
-                onClick: async ids => {
-                    await usecases.landings.delete(ids);
-                    await reload();
-                },
-                isActive: nodes => _.every(nodes, item => item.id !== "root"),
-            },
-            {
-                name: "export-landing-page",
-                text: i18n.t("Export landing page"),
-                icon: <Icon>cloud_download</Icon>,
-                onClick: async (ids: string[]) => {
-                    if (!ids[0]) return;
-                    loading.show(true, i18n.t("Exporting landing page(s)"));
-                    await usecases.landings.export(ids);
-                    loading.reset();
-                },
-                isActive: nodes => _.every(nodes, item => item.type === "root"),
-                multiple: true,
-            },
-            {
-                name: "export-translations",
-                text: i18n.t("Export JSON translations"),
-                icon: <Icon>translate</Icon>,
-                onClick: async () => {
-                    loading.show(true, i18n.t("Exporting translations"));
-                    await exportTranslation(() => usecases.landings.extractTranslations(), "landing-page");
-                    loading.reset();
-                },
-                isActive: nodes => _.every(nodes, item => item.type === "root"),
-                multiple: false,
-            },
-            {
-                name: "move-up",
-                text: i18n.t("Move up"),
-                icon: <Icon>arrow_upwards</Icon>,
-                onClick: ids => move(ids, nodes, "up"),
-                isActive: nodes => _.every(nodes, ({ type, order }) => type !== "root" && order !== 0),
-                multiple: false,
-            },
-            {
-                name: "move-down",
-                text: i18n.t("Move down"),
-                icon: <Icon>arrow_downwards</Icon>,
-                onClick: ids => move(ids, nodes, "down"),
-                isActive: (nodes: OrderedLandingNode[]) =>
-                    _.every(nodes, ({ type, order, lastOrder }) => type !== "root" && order !== lastOrder),
-                multiple: false,
-            },
-        ],
+        () =>
+            buildTableActions({
+                usecases,
+                reload,
+                loading,
+                nodes,
+                exportTranslation,
+                onAddCategory,
+                onEditLandingNode,
+                onAddSection,
+                onAddSubSection,
+                setPermissionLandingNodeId,
+            }),
         [
             usecases,
             reload,
             loading,
             nodes,
-            move,
             exportTranslation,
             onAddCategory,
             onEditLandingNode,
             onAddSection,
             onAddSubSection,
+            setPermissionLandingNodeId,
         ]
     );
 
     const globalActions: Maybe<TableGlobalAction[]> = useMemo(
-        () => [
-            {
-                name: "import",
-                text: i18n.t("Import landing pages"),
-                icon: <Icon>arrow_upward</Icon>,
-                onClick: openImportDialog,
-            },
-            {
-                name: "import-translations",
-                text: i18n.t("Import JSON translations"),
-                icon: <Icon>translate</Icon>,
-                onClick: () => {
-                    translationImportRef.current?.startImport();
-                },
-            },
-        ],
+        () => buildGlobalActions({ translationImportRef, openImportDialog }),
         [openImportDialog]
     );
 
+    const permissionDialogProps: Maybe<PermissionHandlerProps> = useMemo(() => {
+        if (!permissionLandingNodeId) return;
+        const landingNode = flattenRows(nodes).find(({ id }) => id === permissionLandingNodeId);
+        if (!landingNode) return;
+
+        return {
+            object: {
+                ...landingNode.permissions,
+                name: i18n.t("Access to landing page"),
+            },
+            onChange: async ({ userAccesses, userGroupAccesses, publicAccess }) => {
+                const updatedLandingNode = {
+                    ...landingNode,
+                    permissions: {
+                        userAccesses: userAccesses || landingNode.permissions.userAccesses,
+                        userGroupAccesses: userGroupAccesses || landingNode.permissions.userGroupAccesses,
+                        publicAccess: publicAccess || landingNode.permissions.publicAccess,
+                    },
+                };
+                await usecases.landings.update(updatedLandingNode);
+                await reload();
+            },
+        };
+    }, [permissionLandingNodeId, nodes]);
+
     return (
         <React.Fragment>
+            {permissionDialogProps && (
+                <PermissionsDialog
+                    allowPublicAccess
+                    onClose={closePermissionsDialog}
+                    {...permissionDialogProps}
+                    showOptions={defaultShowOptions}
+                />
+            )}
             {dialogProps && <ConfirmationDialog isOpen={true} maxWidth={"xl"} {...dialogProps} />}
 
             <ImportTranslationDialog type="landing-page" ref={translationImportRef} onSave={handleTranslationUpload} />
@@ -287,6 +189,197 @@ export const LandingPageListTable: React.FC<LandingPageListTableProps> = props =
         </React.Fragment>
     );
 };
+
+const defaultShowOptions = {
+    publicSharing: true,
+    permissionPicker: true,
+};
+
+type BuildTableActionsProps = Pick<
+    LandingPageListTableProps,
+    "onAddSection" | "onAddSubSection" | "onAddCategory" | "onEditLandingNode" | "nodes"
+> & {
+    usecases: CompositionRoot["usecases"];
+    reload: () => Promise<void>;
+    exportTranslation: (exporter: () => Promise<Translations>, type: string) => Promise<void>;
+    loading: LoadingState;
+    setPermissionLandingNodeId: (value: Maybe<string>) => void;
+};
+function buildTableActions(props: BuildTableActionsProps): TableAction<LandingNode>[] {
+    const {
+        usecases,
+        reload,
+        exportTranslation,
+        nodes,
+        onAddSection,
+        onAddSubSection,
+        onAddCategory,
+        onEditLandingNode,
+        loading,
+        setPermissionLandingNodeId,
+    } = props;
+
+    const move = async (ids: string[], nodes: LandingNode[], change: "up" | "down") => {
+        const orderChange = change === "up" ? -1 : 1;
+        const allNodes = flattenRows(nodes);
+
+        const firstNode = allNodes.find(({ id }) => id === ids[0]);
+        if (firstNode?.order === undefined) return;
+
+        const parent = allNodes.find(({ id }) => id === firstNode?.parent);
+        const secondNode = parent?.children[firstNode?.order + orderChange];
+        if (secondNode?.order === undefined) return;
+
+        await usecases.landings.swapOrder(firstNode, secondNode);
+        await reload();
+    };
+
+    return [
+        {
+            name: "add-section",
+            text: i18n.t("Add section"),
+            icon: <Icon>add</Icon>,
+            onClick: onAddSection,
+            isActive: nodes => _.every(nodes, item => item.type === "root"),
+        },
+        {
+            name: "add-sub-section",
+            text: i18n.t("Add sub-section"),
+            icon: <Icon>add</Icon>,
+            onClick: onAddSubSection,
+            isActive: nodes => _.every(nodes, item => item.type === "section"),
+        },
+        {
+            name: "add-category",
+            text: i18n.t("Add category"),
+            icon: <Icon>add</Icon>,
+            onClick: onAddCategory,
+            isActive: nodes => _.every(nodes, item => item.type === "sub-section" || item.type === "category"),
+        },
+        {
+            name: "edit",
+            text: i18n.t("Edit"),
+            icon: <Icon>edit</Icon>,
+            onClick: onEditLandingNode,
+            isActive: nodes => _.every(nodes, item => item.type !== "root"),
+        },
+        {
+            name: "sharing",
+            text: i18n.t("Sharing settings"),
+            icon: <Icon>share</Icon>,
+            onClick: ids => {
+                const landingNode = flattenRows(nodes).find(({ id }) => id === ids[0]);
+                if (!landingNode) return;
+                setPermissionLandingNodeId(landingNode.id);
+            },
+        },
+        {
+            name: "remove",
+            text: i18n.t("Delete"),
+            icon: <Icon>delete</Icon>,
+            multiple: true,
+            onClick: async ids => {
+                await usecases.landings.delete(ids);
+                await reload();
+            },
+            isActive: nodes => _.every(nodes, item => item.id !== "root"),
+        },
+        {
+            name: "export-landing-page",
+            text: i18n.t("Export landing page"),
+            icon: <Icon>cloud_download</Icon>,
+            onClick: async (ids: string[]) => {
+                if (!ids[0]) return;
+                loading.show(true, i18n.t("Exporting landing page(s)"));
+                await usecases.landings.export(ids);
+                loading.reset();
+            },
+            isActive: nodes => _.every(nodes, item => item.type === "root"),
+            multiple: true,
+        },
+        {
+            name: "export-translations",
+            text: i18n.t("Export JSON translations"),
+            icon: <Icon>translate</Icon>,
+            onClick: async () => {
+                loading.show(true, i18n.t("Exporting translations"));
+                await exportTranslation(() => usecases.landings.extractTranslations(), "landing-page");
+                loading.reset();
+            },
+            isActive: nodes => _.every(nodes, item => item.type === "root"),
+            multiple: false,
+        },
+        {
+            name: "move-up",
+            text: i18n.t("Move up"),
+            icon: <Icon>arrow_upwards</Icon>,
+            onClick: ids => move(ids, nodes, "up"),
+            isActive: nodes => _.every(nodes, ({ type, order }) => type !== "root" && order !== 0),
+            multiple: false,
+        },
+        {
+            name: "move-down",
+            text: i18n.t("Move down"),
+            icon: <Icon>arrow_downwards</Icon>,
+            onClick: ids => move(ids, nodes, "down"),
+            isActive: (nodes: OrderedLandingNode[]) =>
+                _.every(nodes, ({ type, order, lastOrder }) => type !== "root" && order !== lastOrder),
+            multiple: false,
+        },
+    ];
+}
+
+function buildGlobalActions(props: {
+    translationImportRef: React.RefObject<ImportTranslationRef>;
+    openImportDialog: () => Promise<void>;
+}) {
+    const { translationImportRef, openImportDialog } = props;
+    return [
+        {
+            name: "import",
+            text: i18n.t("Import landing pages"),
+            icon: <Icon>arrow_upward</Icon>,
+            onClick: openImportDialog,
+        },
+        {
+            name: "import-translations",
+            text: i18n.t("Import JSON translations"),
+            icon: <Icon>translate</Icon>,
+            onClick: () => {
+                translationImportRef.current?.startImport();
+            },
+        },
+    ];
+}
+
+const columns: TableColumn<LandingNode>[] = [
+    {
+        name: "type",
+        text: "Type",
+        sortable: false,
+        getValue: item => getTypeName(item.type),
+    },
+    {
+        name: "name",
+        text: "Name",
+        getValue: item => item.name?.referenceValue ?? "-",
+    },
+    {
+        name: "title",
+        text: "Title",
+        getValue: item => item.title?.referenceValue ?? "-",
+    },
+    {
+        name: "content",
+        text: "Content",
+        getValue: item => (item.content ? <StepPreview value={item.content.referenceValue} /> : "-"),
+    },
+    {
+        name: "icon",
+        text: "Icon",
+        getValue: item => (item.icon ? <ItemIcon src={item.icon} alt={`Icon for ${item.name.referenceValue}`} /> : "-"),
+    },
+];
 
 const getTypeName = (type: LandingNodeType) => {
     switch (type) {

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -156,7 +156,7 @@ export const LandingPageListTable: React.FC<LandingPageListTableProps> = props =
                 await reload();
             },
         };
-    }, [permissionLandingNodeId, nodes]);
+    }, [permissionLandingNodeId, nodes, reload, usecases.landings]);
 
     return (
         <React.Fragment>

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -301,9 +301,10 @@ function buildTableActions(props: BuildTableActionsProps): TableAction<LandingNo
             name: "export-translations",
             text: i18n.t("Export JSON translations"),
             icon: <Icon>translate</Icon>,
-            onClick: async () => {
+            onClick: async (ids: string[]) => {
+                if (!ids[0]) return;
                 loading.show(true, i18n.t("Exporting translations"));
-                await exportTranslation(() => usecases.landings.extractTranslations(), "landing-page");
+                await exportTranslation(() => usecases.landings.extractTranslations(ids[0]), "landing-page");
                 loading.reset();
             },
             isActive: nodes => _.every(nodes, item => item.type === "root"),

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -20,7 +20,7 @@ import {
     buildOrderedLandingNodes,
 } from "../../../domain/entities/LandingPage";
 import i18n from "../../../utils/i18n";
-import { MarkdownViewer } from "../../components/markdown-viewer/MarkdownViewer";
+import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
 import { useAppContext } from "../../contexts/app-context";
 import { Dropzone, DropzoneRef } from "../dropzone/Dropzone";
 import { ImportTranslationDialog, ImportTranslationRef } from "../import-translation-dialog/ImportTranslationDialog";

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -261,7 +261,6 @@ function buildTableActions(props: BuildTableActionsProps): TableAction<LandingNo
             text: i18n.t("Edit"),
             icon: <Icon>edit</Icon>,
             onClick: onEditLandingNode,
-            isActive: nodes => _.every(nodes, item => item.type !== "root"),
         },
         {
             name: "sharing",
@@ -272,6 +271,7 @@ function buildTableActions(props: BuildTableActionsProps): TableAction<LandingNo
                 if (!landingNode) return;
                 setPermissionLandingNodeId(landingNode.id);
             },
+            isActive: nodes => _.every(nodes, item => item.type !== "root"),
         },
         {
             name: "remove",

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -98,7 +98,7 @@ export const LandingPageListTable: React.FC<LandingPageListTableProps> = props =
             await importTranslation(() => usecases.landings.importTranslations(lang, terms));
             await reload();
         },
-        [usecases.landings, importTranslation]
+        [usecases.landings, importTranslation, reload]
     );
 
     const actions: TableAction<LandingNode>[] = useMemo(

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -283,7 +283,6 @@ function buildTableActions(props: BuildTableActionsProps): TableAction<LandingNo
                 await usecases.landings.delete(ids);
                 await reload();
             },
-            isActive: nodes => _.every(nodes, item => item.id !== "root"),
         },
         {
             name: "export-landing-page",

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -96,6 +96,7 @@ export const LandingPageListTable: React.FC<LandingPageListTableProps> = props =
     const handleTranslationUpload = useCallback(
         async (_key: string | undefined, lang: string, terms: Record<string, string>) => {
             await importTranslation(() => usecases.landings.importTranslations(lang, terms));
+            await reload();
         },
         [usecases.landings, importTranslation]
     );

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -271,7 +271,7 @@ function buildTableActions(props: BuildTableActionsProps): TableAction<LandingNo
                 if (!landingNode) return;
                 setPermissionLandingNodeId(landingNode.id);
             },
-            isActive: nodes => _.every(nodes, item => item.type !== "root"),
+            isActive: nodes => _.every(nodes, item => item.type === "root"),
         },
         {
             name: "remove",

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -20,15 +20,27 @@ import {
     buildOrderedLandingNodes,
 } from "../../../domain/entities/LandingPage";
 import i18n from "../../../utils/i18n";
-import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
 import { useAppContext } from "../../contexts/app-context";
 import { Dropzone, DropzoneRef } from "../dropzone/Dropzone";
 import { ImportTranslationDialog, ImportTranslationRef } from "../import-translation-dialog/ImportTranslationDialog";
-import { LandingPageEditDialog, LandingPageEditDialogProps } from "../landing-page-edit-dialog/LandingPageEditDialog";
-import { ModalBody } from "../modal";
 import { useImportExportTranslation } from "../../hooks/useImportExportTranslation";
+import { StepPreview } from "../step-preview/StepPreview";
+import { Maybe } from "../../../types/utils";
 
-export const LandingPageListTable: React.FC<{ nodes: LandingNode[]; isLoading?: boolean }> = ({ nodes, isLoading }) => {
+type LandingNodeAction = (ids: string[]) => void;
+
+type LandingPageListTableProps = {
+    nodes: LandingNode[];
+    isLoading?: boolean;
+    onAddSection: LandingNodeAction;
+    onAddSubSection: LandingNodeAction;
+    onAddCategory: LandingNodeAction;
+    onEditLandingNode: LandingNodeAction;
+};
+
+export const LandingPageListTable: React.FC<LandingPageListTableProps> = props => {
+    const { nodes, isLoading, onAddSection, onAddSubSection, onAddCategory, onEditLandingNode } = props;
+
     const { usecases, reload } = useAppContext();
     const { exportTranslation, importTranslation } = useImportExportTranslation();
 
@@ -39,7 +51,6 @@ export const LandingPageListTable: React.FC<{ nodes: LandingNode[]; isLoading?: 
     const translationImportRef = useRef<ImportTranslationRef>(null);
 
     const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
-    const [editDialogProps, updateEditDialog] = useState<LandingPageEditDialogProps | null>(null);
 
     const openImportDialog = useCallback(async () => {
         landingImportRef.current?.openDialog();
@@ -141,93 +152,28 @@ export const LandingPageListTable: React.FC<{ nodes: LandingNode[]; isLoading?: 
                 name: "add-section",
                 text: i18n.t("Add section"),
                 icon: <Icon>add</Icon>,
-                onClick: ids => {
-                    const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
-                    if (!parent) return;
-
-                    updateEditDialog({
-                        title: i18n.t("Add section"),
-                        type: "section",
-                        parent: parent.id,
-                        order: parent.children.length,
-                        onCancel: () => updateEditDialog(null),
-                        onSave: async node => {
-                            updateEditDialog(null);
-                            await usecases.landings.update(node);
-                            await reload();
-                        },
-                    });
-                },
+                onClick: onAddSection,
                 isActive: nodes => _.every(nodes, item => item.type === "root"),
             },
             {
                 name: "add-sub-section",
                 text: i18n.t("Add sub-section"),
                 icon: <Icon>add</Icon>,
-                onClick: ids => {
-                    const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
-                    if (!parent) return;
-
-                    updateEditDialog({
-                        title: i18n.t("Add sub-section"),
-                        type: "sub-section",
-                        parent: parent.id,
-                        order: parent.children.length,
-                        onCancel: () => updateEditDialog(null),
-                        onSave: async node => {
-                            updateEditDialog(null);
-                            await usecases.landings.update(node);
-                            await reload();
-                        },
-                    });
-                },
+                onClick: onAddSubSection,
                 isActive: nodes => _.every(nodes, item => item.type === "section"),
             },
             {
                 name: "add-category",
                 text: i18n.t("Add category"),
                 icon: <Icon>add</Icon>,
-                onClick: ids => {
-                    const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
-                    if (!parent) return;
-
-                    updateEditDialog({
-                        title: i18n.t("Add category"),
-                        type: "category",
-                        parent: parent.id,
-                        order: parent.children.length,
-                        onCancel: () => updateEditDialog(null),
-                        onSave: async node => {
-                            updateEditDialog(null);
-                            await usecases.landings.update(node);
-                            await reload();
-                        },
-                    });
-                },
+                onClick: onAddCategory,
                 isActive: nodes => _.every(nodes, item => item.type === "sub-section" || item.type === "category"),
             },
             {
                 name: "edit",
                 text: i18n.t("Edit"),
                 icon: <Icon>edit</Icon>,
-                onClick: ids => {
-                    const node = flattenRows(nodes).find(({ id }) => id === ids[0]);
-                    if (!node) return;
-
-                    updateEditDialog({
-                        title: i18n.t("Edit"),
-                        type: node.type,
-                        parent: node.parent,
-                        initialNode: node,
-                        order: node.order ?? 0,
-                        onCancel: () => updateEditDialog(null),
-                        onSave: async node => {
-                            updateEditDialog(null);
-                            await usecases.landings.update(node);
-                            await reload();
-                        },
-                    });
-                },
+                onClick: onEditLandingNode,
                 isActive: nodes => _.every(nodes, item => item.type !== "root"),
             },
             {
@@ -284,10 +230,21 @@ export const LandingPageListTable: React.FC<{ nodes: LandingNode[]; isLoading?: 
                 multiple: false,
             },
         ],
-        [usecases, reload, loading, nodes, move, exportTranslation]
+        [
+            usecases,
+            reload,
+            loading,
+            nodes,
+            move,
+            exportTranslation,
+            onAddCategory,
+            onEditLandingNode,
+            onAddSection,
+            onAddSubSection,
+        ]
     );
 
-    const globalActions: TableGlobalAction[] | undefined = useMemo(
+    const globalActions: Maybe<TableGlobalAction[]> = useMemo(
         () => [
             {
                 name: "import",
@@ -310,7 +267,6 @@ export const LandingPageListTable: React.FC<{ nodes: LandingNode[]; isLoading?: 
     return (
         <React.Fragment>
             {dialogProps && <ConfirmationDialog isOpen={true} maxWidth={"xl"} {...dialogProps} />}
-            {editDialogProps && <LandingPageEditDialog isOpen={true} {...editDialogProps} />}
 
             <ImportTranslationDialog type="landing-page" ref={translationImportRef} onSave={handleTranslationUpload} />
 
@@ -353,21 +309,4 @@ const flattenRows = (rows: LandingNode[]): LandingNode[] => {
 
 const ItemIcon = styled.img`
     width: 100px;
-`;
-
-const StepPreview: React.FC<{
-    className?: string;
-    value?: string;
-}> = ({ className, value }) => {
-    if (!value) return null;
-
-    return (
-        <StyledModalBody className={className}>
-            <MarkdownViewer source={value} />
-        </StyledModalBody>
-    );
-};
-
-const StyledModalBody = styled(ModalBody)`
-    max-width: 600px;
 `;

--- a/src/webapp/components/migrations/Migrations.tsx
+++ b/src/webapp/components/migrations/Migrations.tsx
@@ -1,5 +1,6 @@
 import { ConfirmationDialog } from "@eyeseetea/d2-ui-components";
 import React from "react";
+
 import i18n from "../../../locales";
 import { UseMigrationsResult } from "./useMigration";
 import { MigrationsRunner } from "../../../migrations";

--- a/src/webapp/components/migrations/Migrations.tsx
+++ b/src/webapp/components/migrations/Migrations.tsx
@@ -1,0 +1,158 @@
+import { ConfirmationDialog } from "@eyeseetea/d2-ui-components";
+import React from "react";
+import i18n from "../../../locales";
+import { UseMigrationsResult } from "./useMigration";
+import { MigrationsRunner } from "../../../migrations";
+
+export interface MigrationsProps {
+    migrations: UseMigrationsResult;
+}
+
+export interface MigrationsRunnerProps {
+    runner: MigrationsRunner;
+    onFinish: () => void;
+}
+
+const Migrations: React.FC<MigrationsProps> = props => {
+    const { state, onFinish } = props.migrations;
+
+    if (state.type === "checking" || state.type === "checked") {
+        return null;
+    } else {
+        return <MigrationsDialog runner={state.runner} onFinish={onFinish} />;
+    }
+};
+
+type DialogState = { type: "show-info" } | { type: "app-out-of-date" } | { type: "migrating" } | { type: "success" };
+
+const MigrationsDialog: React.FC<MigrationsRunnerProps> = props => {
+    const { runner, onFinish } = props;
+    const [messages, setMessages] = React.useState<string[]>([]);
+
+    const [state, setState] = React.useState<DialogState>(getInitialState(runner));
+    React.useEffect(followContents, [messages]);
+
+    const debug = React.useCallback((message: string) => {
+        setMessages(messages => [...messages, message]);
+    }, []);
+
+    const startMigration = React.useCallback(() => {
+        runMigrations(runner, debug, setState).then(setState);
+    }, [runner, debug]);
+
+    const actionText = getActionText(state);
+
+    if (state.type === "app-out-of-date") {
+        return <MigrationsError runner={runner} onFinish={onFinish} />;
+    }
+
+    return (
+        <ConfirmationDialog
+            isOpen={true}
+            title={i18n.t("There are pending migrations")}
+            onSave={() => (state.type === "success" ? onFinish() : startMigration())}
+            saveText={actionText}
+            onCancel={undefined}
+            disableSave={state.type === "migrating" || !actionText}
+            maxWidth="md"
+            fullWidth={true}
+        >
+            <div id="migrations-contents">
+                <p>{getPendingMigrationsText(runner)}</p>
+
+                <p>
+                    {messages.map((msg, idx) => (
+                        <React.Fragment key={idx}>
+                            {msg}
+                            <br />
+                        </React.Fragment>
+                    ))}
+                </p>
+
+                <p>
+                    {state.type === "success" &&
+                        i18n.t("Migrations finished successfully, you may now continue to the app")}
+                </p>
+            </div>
+        </ConfirmationDialog>
+    );
+};
+
+function runMigrations(
+    runner: MigrationsRunner,
+    debug: (message: string) => void,
+    setState: React.Dispatch<React.SetStateAction<DialogState>>
+): Promise<DialogState> {
+    setState({ type: "migrating" });
+
+    return runner
+        .setDebug(debug)
+        .execute()
+        .then(() => ({ type: "success" as const }))
+        .catch(err => {
+            debug("---");
+            debug(`Error: ${err.message}`);
+            debug(
+                i18n.t(
+                    "There has been an error. You can either retry or contact your administrator if you think there has been an un recoverable error"
+                )
+            );
+            return { type: "show-info" as const };
+        });
+}
+
+function followContents() {
+    const contentsEl = document.getElementById("migrations-contents");
+    const divEl = contentsEl ? contentsEl.parentElement : null;
+    if (divEl) divEl.scrollTop = divEl.scrollHeight;
+}
+
+function getActionText(state: DialogState): string | undefined {
+    switch (state.type) {
+        case "show-info":
+            return i18n.t("Migrate instance");
+        case "migrating":
+            return i18n.t("Migrating...");
+        case "success":
+            return i18n.t("Continue to the App");
+        case "app-out-of-date":
+            return;
+    }
+}
+
+function getInitialState(runner: MigrationsRunner): DialogState {
+    if (runner.instanceVersion === runner.appVersion) {
+        return { type: "success" };
+    } else if (runner.instanceVersion > runner.appVersion) {
+        return { type: "app-out-of-date" };
+    } else {
+        return { type: "show-info" };
+    }
+}
+
+function getPendingMigrationsText(runner: MigrationsRunner): string {
+    return i18n.t(
+        "The app needs to run pending migrations (from version {{instanceVersion}} to version {{appVersion}}) in order to continue. This may take a long time, make sure the process is not interrupted.",
+        runner
+    );
+}
+
+const isDebug = process.env.NODE_ENV === "development";
+
+const MigrationsError: React.FC<{ runner: MigrationsRunner; onFinish: () => void }> = ({ runner, onFinish }) => (
+    <ConfirmationDialog
+        isOpen={true}
+        title={i18n.t("Error")}
+        onSave={isDebug ? onFinish : undefined}
+        saveText={i18n.t("Continue to the app anyway")}
+        maxWidth="md"
+        fullWidth={true}
+    >
+        {i18n.t(
+            "The database version ({{instanceVersion}}) is greater than the app version ({{appVersion}}), cannot continue. Please contact the administrator to update the app.",
+            runner
+        )}
+    </ConfirmationDialog>
+);
+
+export default Migrations;

--- a/src/webapp/components/migrations/useMigration.ts
+++ b/src/webapp/components/migrations/useMigration.ts
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { MigrationsRunner } from "../../../migrations";
 import { D2Api } from "../../../types/d2-api";
 import { getMigrationTasks } from "../../../migrations/tasks";

--- a/src/webapp/components/migrations/useMigration.ts
+++ b/src/webapp/components/migrations/useMigration.ts
@@ -1,0 +1,42 @@
+import React from "react";
+import { MigrationsRunner } from "../../../migrations";
+import { D2Api } from "../../../types/d2-api";
+import { getMigrationTasks } from "../../../migrations/tasks";
+
+export type MigrationsState =
+    | { type: "checking" }
+    | { type: "pending"; runner: MigrationsRunner }
+    | { type: "checked" };
+
+export interface UseMigrationsResult {
+    state: MigrationsState;
+    onFinish: () => void;
+}
+
+export function useMigrations(api: D2Api, dataStoreNamespace: string): UseMigrationsResult {
+    const [state, setState] = React.useState<MigrationsState>({ type: "checking" });
+    const onFinish = React.useCallback(() => setState({ type: "checked" }), [setState]);
+
+    React.useEffect(() => {
+        runMigrations(api, dataStoreNamespace).then(setState);
+    }, [api, dataStoreNamespace]);
+
+    const result = React.useMemo(() => ({ state, onFinish }), [state, onFinish]);
+
+    return result;
+}
+
+async function runMigrations(api: D2Api, dataStoreNamespace: string): Promise<MigrationsState> {
+    const runner = await MigrationsRunner.init({
+        api,
+        debug: console.log,
+        migrations: await getMigrationTasks(),
+        dataStoreNamespace,
+    });
+
+    if (runner.hasPendingMigrations()) {
+        return { type: "pending", runner };
+    } else {
+        return { type: "checked" };
+    }
+}

--- a/src/webapp/components/migrations/useMigration.ts
+++ b/src/webapp/components/migrations/useMigration.ts
@@ -30,7 +30,7 @@ export function useMigrations(api: D2Api, dataStoreNamespace: string): UseMigrat
 async function runMigrations(api: D2Api, dataStoreNamespace: string): Promise<MigrationsState> {
     const runner = await MigrationsRunner.init({
         api,
-        debug: console.log,
+        debug: console.debug,
         migrations: await getMigrationTasks(),
         dataStoreNamespace,
     });

--- a/src/webapp/components/module-creation-wizard/steps/ContentsStep.tsx
+++ b/src/webapp/components/module-creation-wizard/steps/ContentsStep.tsx
@@ -8,15 +8,11 @@ import {
     updateTranslation,
 } from "../../../../domain/helpers/TrainingModuleHelpers";
 import i18n from "../../../../utils/i18n";
-import { ComponentParameter } from "../../../../types/utils";
-import { useAppContext } from "../../../contexts/app-context";
 import { InputDialog, InputDialogProps } from "../../input-dialog/InputDialog";
-import { buildListSteps, ModuleListTable } from "../../module-list-table/ModuleListTable";
+import { buildListSteps, ModuleListTable, ModuleListTableAction } from "../../module-list-table/ModuleListTable";
 import { ModuleCreationWizardStepProps } from "./index";
 
 export const ContentsStep: React.FC<ModuleCreationWizardStepProps> = ({ module, onChange }) => {
-    const { usecases } = useAppContext();
-
     const [dialogProps, updateDialog] = useState<InputDialogProps | null>(null);
 
     const openAddStep = useCallback(() => {
@@ -33,9 +29,8 @@ export const ContentsStep: React.FC<ModuleCreationWizardStepProps> = ({ module, 
         });
     }, [onChange]);
 
-    const tableActions: ComponentParameter<typeof ModuleListTable, "tableActions"> = useMemo(
+    const tableActions: ModuleListTableAction = useMemo(
         () => ({
-            uploadFile: ({ data, name }) => usecases.document.uploadFile(data, name),
             editContents: async ({ text, value }) => onChange(module => updateTranslation(module, text.key, value)),
             swap: async ({ type, from, to }) => {
                 if (type === "module") return;
@@ -46,7 +41,7 @@ export const ContentsStep: React.FC<ModuleCreationWizardStepProps> = ({ module, 
             deleteStep: async ({ step }) => onChange(module => removeStep(module, step)),
             deletePage: async ({ step, page }) => onChange(module => removePage(module, step, page)),
         }),
-        [onChange, usecases]
+        [onChange]
     );
 
     return (

--- a/src/webapp/components/module-list-table/ModuleListTable.tsx
+++ b/src/webapp/components/module-list-table/ModuleListTable.tsx
@@ -80,7 +80,7 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = props => {
             await importTranslation(() => usecases.modules.importTranslations(lang, terms, key));
             await refreshRows();
         },
-        [usecases, importTranslation]
+        [usecases, importTranslation, refreshRows]
     );
 
     return (

--- a/src/webapp/components/module-list-table/ModuleListTable.tsx
+++ b/src/webapp/components/module-list-table/ModuleListTable.tsx
@@ -26,7 +26,7 @@ export interface ModuleListTableProps {
 }
 
 export const ModuleListTable: React.FC<ModuleListTableProps> = props => {
-    const { rows, onActionButtonClick, refreshRows = async () => {}, isLoading } = props;
+    const { rows, onActionButtonClick, refreshRows = async () => {}, isLoading, tableActions } = props;
     const { usecases } = useAppContext();
     const { importTranslation } = useImportExportTranslation();
 
@@ -55,6 +55,7 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = props => {
         rows,
         openImportDialog,
         translationImportRef,
+        tableActions,
     });
 
     const handleFileUpload = useCallback(

--- a/src/webapp/components/module-list-table/ModuleListTable.tsx
+++ b/src/webapp/components/module-list-table/ModuleListTable.tsx
@@ -14,7 +14,6 @@ import { InputDialog } from "../input-dialog/InputDialog";
 import { MarkdownEditorDialog } from "../markdown-editor/MarkdownEditorDialog";
 import { useImportExportTranslation } from "../../hooks/useImportExportTranslation";
 import { SharedProperties } from "../../../domain/entities/Ref";
-import { usePagePermissions } from "./usePagePermissions";
 import { PermissionsDialog } from "../permissions-dialog/PermissionsDialog";
 import { useModuleList } from "./useModuleList";
 
@@ -34,12 +33,6 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = props => {
     const loading = useLoading();
     const snackbar = useSnackbar();
 
-    const { pagePermissionsDialog, openPagePermissions } = usePagePermissions({
-        rows: buildChildrenRows(rows),
-        onChange: tableActions.editPagePermissions,
-        refreshRows,
-    });
-
     const moduleImportRef = useRef<DropzoneRef>(null);
     const translationImportRef = useRef<ImportTranslationRef>(null);
 
@@ -56,6 +49,7 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = props => {
         inputDialogProps,
         confirmDialogProps: dialogProps,
         markdownDialogProps,
+        pagePermissionsDialog,
     } = useModuleList({
         refreshRows,
         rows,

--- a/src/webapp/components/module-list-table/ModuleListTable.tsx
+++ b/src/webapp/components/module-list-table/ModuleListTable.tsx
@@ -78,6 +78,7 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = props => {
         async (key: string | undefined, lang: string, terms: Record<string, string>) => {
             if (!key) return;
             await importTranslation(() => usecases.modules.importTranslations(lang, terms, key));
+            await refreshRows();
         },
         [usecases, importTranslation]
     );

--- a/src/webapp/components/module-list-table/ModuleListTable.tsx
+++ b/src/webapp/components/module-list-table/ModuleListTable.tsx
@@ -30,19 +30,29 @@ import { MarkdownEditorDialog, MarkdownEditorDialogProps } from "../markdown-edi
 import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
 import { ModalBody } from "../modal";
 import { useImportExportTranslation } from "../../hooks/useImportExportTranslation";
+import {
+    addPage,
+    addStep,
+    removePage,
+    removeStep,
+    updateOrder,
+    updateTranslation,
+} from "../../../domain/helpers/TrainingModuleHelpers";
+import { CompositionRoot } from "../../CompositionRoot";
+import { useModuleTableAction } from "./useModuleTableAction";
+import { useModuleList } from "./useModuleList";
 
 export interface ModuleListTableProps {
     rows: ListItem[];
     refreshRows?: () => Promise<void>;
-    tableActions: ModuleListTableAction;
     onActionButtonClick?: (event: React.MouseEvent<unknown>) => void;
     isLoading?: boolean;
 }
 
 export const ModuleListTable: React.FC<ModuleListTableProps> = props => {
-    const { rows, tableActions, onActionButtonClick, refreshRows = async () => {}, isLoading } = props;
+    const { rows, onActionButtonClick, refreshRows = async () => {}, isLoading } = props;
     const { usecases } = useAppContext();
-    const { exportTranslation, importTranslation } = useImportExportTranslation();
+    const { importTranslation } = useImportExportTranslation();
 
     const loading = useLoading();
     const snackbar = useSnackbar();
@@ -50,11 +60,25 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = props => {
     const moduleImportRef = useRef<DropzoneRef>(null);
     const translationImportRef = useRef<ImportTranslationRef>(null);
 
-    const [selection, setSelection] = useState<TableSelection[]>([]);
+    const openImportDialog = useCallback(async () => {
+        moduleImportRef.current?.openDialog();
+    }, [moduleImportRef]);
 
-    const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
-    const [markdownDialogProps, updateMarkdownDialog] = useState<MarkdownEditorDialogProps | null>(null);
-    const [inputDialogProps, updateInputDialog] = useState<InputDialogProps | null>(null);
+    const {
+        globalActions,
+        actions,
+        columns,
+        onTableChange,
+        selection,
+        inputDialogProps,
+        confirmDialogProps: dialogProps,
+        markdownDialogProps,
+    } = useModuleList({
+        refreshRows,
+        rows,
+        openImportDialog,
+        translationImportRef,
+    });
 
     const handleFileUpload = useCallback(
         async (files: File[], rejections: FileRejection[]) => {
@@ -82,564 +106,6 @@ export const ModuleListTable: React.FC<ModuleListTableProps> = props => {
             await importTranslation(() => usecases.modules.importTranslations(lang, terms, key));
         },
         [usecases, importTranslation]
-    );
-
-    const deleteModules = useCallback(
-        async (ids: string[]) => {
-            updateDialog({
-                title: i18n.t("Are you sure you want to delete the selected modules?"),
-                description: i18n.t("This action cannot be reversed"),
-                onCancel: () => {
-                    updateDialog(null);
-                },
-                onSave: async () => {
-                    updateDialog(null);
-                    if (!tableActions.deleteModules) return;
-
-                    loading.show(true, i18n.t("Deleting modules"));
-                    await tableActions.deleteModules({ ids });
-                    loading.reset();
-
-                    snackbar.success("Successfully deleted modules");
-                    setSelection([]);
-                    await refreshRows();
-                },
-                cancelText: i18n.t("Cancel"),
-                saveText: i18n.t("Delete modules"),
-            });
-        },
-        [tableActions, loading, refreshRows, snackbar]
-    );
-
-    const deleteStep = useCallback(
-        async (ids: string[]) => {
-            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
-            if (!row || !row.moduleId) return;
-
-            updateDialog({
-                title: i18n.t("Are you sure you want to delete the selected step and its pages?"),
-                description: i18n.t("This action cannot be reversed"),
-                onCancel: () => {
-                    updateDialog(null);
-                },
-                onSave: async () => {
-                    updateDialog(null);
-                    if (!tableActions.deleteStep || !row.moduleId) return;
-                    await tableActions.deleteStep({ id: row.moduleId, step: row.id });
-                    await refreshRows();
-                },
-                cancelText: i18n.t("Cancel"),
-                saveText: i18n.t("Delete step"),
-            });
-        },
-        [tableActions, refreshRows, rows]
-    );
-
-    const deletePage = useCallback(
-        async (ids: string[]) => {
-            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
-            if (!row || !row.moduleId) return;
-
-            updateDialog({
-                title: i18n.t("Are you sure you want to delete the selected page?"),
-                description: i18n.t("This action cannot be reversed"),
-                onCancel: () => {
-                    updateDialog(null);
-                },
-                onSave: async () => {
-                    updateDialog(null);
-                    if (!tableActions.deletePage || !row.moduleId || !row.stepId) return;
-                    await tableActions.deletePage({ id: row.moduleId, step: row.stepId, page: row.id });
-                    await refreshRows();
-                },
-                cancelText: i18n.t("Cancel"),
-                saveText: i18n.t("Delete page"),
-            });
-        },
-        [tableActions, refreshRows, rows]
-    );
-
-    const addModule = useCallback(() => {
-        if (!tableActions.openCreateModulePage) return;
-        tableActions.openCreateModulePage();
-    }, [tableActions]);
-
-    const addStep = useCallback(
-        async (ids: string[]) => {
-            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
-            if (!row || !tableActions.addStep) return;
-
-            updateInputDialog({
-                title: i18n.t("Add new step"),
-                inputLabel: i18n.t("Title *"),
-                onCancel: () => updateInputDialog(null),
-                onSave: async title => {
-                    updateInputDialog(null);
-                    if (!tableActions.addStep) return;
-
-                    await tableActions.addStep({ id: row.id, title });
-                    await refreshRows();
-                },
-            });
-        },
-        [tableActions, rows, refreshRows]
-    );
-
-    const addPage = useCallback(
-        async (ids: string[]) => {
-            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
-            if (!row) return;
-
-            const { uploadFile } = tableActions;
-
-            updateMarkdownDialog({
-                title: i18n.t("Add new page"),
-                markdownPreview: markdown => <StepPreview value={markdown} />,
-                onUpload: uploadFile
-                    ? (data: ArrayBuffer, file: File) => uploadFile({ data, name: file.name })
-                    : undefined,
-                onCancel: () => updateMarkdownDialog(null),
-                onSave: async value => {
-                    updateMarkdownDialog(null);
-                    if (!row.moduleId || !tableActions.addPage) return;
-
-                    await tableActions.addPage({ id: row.moduleId, step: row.id, value });
-                    await refreshRows();
-                },
-            });
-        },
-        [tableActions, rows, refreshRows]
-    );
-
-    const editModule = useCallback(
-        (ids: string[]) => {
-            if (!tableActions.openEditModulePage || !ids[0]) return;
-            tableActions.openEditModulePage({ id: ids[0] });
-        },
-        [tableActions]
-    );
-
-    const cloneModule = useCallback(
-        (ids: string[]) => {
-            if (!tableActions.openCloneModulePage || !ids[0]) return;
-            tableActions.openCloneModulePage({ id: ids[0] });
-        },
-        [tableActions]
-    );
-
-    const moveUp = useCallback(
-        async (ids: string[]) => {
-            const allRows = buildChildrenRows(rows);
-            const rowIndex = _.findIndex(allRows, ({ id }) => id === ids[0]);
-            const row = allRows[rowIndex];
-            if (!tableActions.swap || rowIndex === -1 || rowIndex === 0 || !row) return;
-
-            const { id: prevRowId } = allRows[rowIndex - 1] ?? {};
-            const moduleId = row.rowType === "module" ? row.id : row.moduleId;
-            if (prevRowId && ids[0] && moduleId) {
-                await tableActions.swap({ id: moduleId, type: row.rowType, from: ids[0], to: prevRowId });
-            }
-
-            await refreshRows();
-        },
-        [tableActions, rows, refreshRows]
-    );
-
-    const moveDown = useCallback(
-        async (ids: string[]) => {
-            const allRows = buildChildrenRows(rows);
-            const rowIndex = _.findIndex(allRows, ({ id }) => id === ids[0]);
-            const row = allRows[rowIndex];
-            if (!tableActions.swap || rowIndex === -1 || rowIndex === allRows.length - 1 || !row) return;
-
-            const { id: nextRowId } = allRows[rowIndex + 1] ?? {};
-            const moduleId = row.rowType === "module" ? row.id : row.moduleId;
-            if (nextRowId && ids[0] && moduleId) {
-                await tableActions.swap({ id: moduleId, type: row.rowType, from: ids[0], to: nextRowId });
-            }
-
-            await refreshRows();
-        },
-        [tableActions, rows, refreshRows]
-    );
-
-    const editStep = useCallback(
-        (ids: string[]) => {
-            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
-            if (!row || !row.title) return;
-
-            updateInputDialog({
-                title: i18n.t("Edit step"),
-                inputLabel: i18n.t("Title *"),
-                initialValue: row.title.referenceValue,
-                onCancel: () => updateInputDialog(null),
-                onSave: async value => {
-                    updateInputDialog(null);
-                    if (!tableActions.editContents || !row.title || !row.moduleId) return;
-
-                    await tableActions.editContents({ id: row.moduleId, text: row.title, value });
-                    await refreshRows();
-                },
-            });
-        },
-        [tableActions, rows, refreshRows]
-    );
-
-    const editPage = useCallback(
-        (ids: string[]) => {
-            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
-            if (!row || !row.value) return;
-
-            const { uploadFile } = tableActions;
-
-            updateMarkdownDialog({
-                title: i18n.t("Edit contents of {{name}}", row),
-                initialValue: row.value.referenceValue,
-                markdownPreview: markdown => <StepPreview value={markdown} />,
-                onUpload: uploadFile
-                    ? (data: ArrayBuffer, file: File) => uploadFile({ data, name: file.name })
-                    : undefined,
-                onCancel: () => updateMarkdownDialog(null),
-                onSave: async value => {
-                    updateMarkdownDialog(null);
-                    if (!tableActions.editContents || !row.value || !row.moduleId) return;
-
-                    await tableActions.editContents({ id: row.moduleId, text: row.value, value });
-                    await refreshRows();
-                },
-            });
-        },
-        [tableActions, rows, refreshRows]
-    );
-
-    const installApp = useCallback(
-        async (ids: string[]) => {
-            if (!tableActions.installApp || !ids[0]) return;
-
-            loading.show(true, i18n.t("Installing application"));
-            const installed = await tableActions.installApp({ id: ids[0] });
-            loading.reset();
-
-            if (!installed) {
-                snackbar.error("Error installing app");
-                return;
-            }
-
-            snackbar.success("Successfully installed app");
-            await refreshRows();
-        },
-        [tableActions, snackbar, loading, refreshRows]
-    );
-
-    const resetModules = useCallback(
-        (ids: string[]) => {
-            updateDialog({
-                title: i18n.t("Are you sure you want to reset selected modules to its default value?"),
-                description: i18n.t("This action cannot be reversed."),
-                onCancel: () => updateDialog(null),
-                onSave: async () => {
-                    updateDialog(null);
-                    if (!tableActions.resetModules) return;
-
-                    loading.show(true, i18n.t("Resetting modules to default value"));
-                    await tableActions.resetModules({ ids });
-                    loading.reset();
-
-                    snackbar.success(i18n.t("Successfully resetted modules to default value"));
-                    await refreshRows();
-                },
-                cancelText: i18n.t("Cancel"),
-                saveText: i18n.t("Reset app to factory settings"),
-            });
-        },
-        [tableActions, loading, refreshRows, snackbar]
-    );
-
-    const exportModule = useCallback(
-        async (ids: string[]) => {
-            if (!ids[0]) return;
-            loading.show(true, i18n.t("Exporting module(s)"));
-            await usecases.modules.export(ids);
-            loading.reset();
-        },
-        [loading, usecases]
-    );
-
-    const exportTranslations = useCallback(
-        async (ids: string[]) => {
-            if (!ids[0]) return;
-            loading.show(true, i18n.t("Exporting translations"));
-            await exportTranslation(() => usecases.modules.extractTranslations(ids[0]), ids[0]);
-            loading.reset();
-        },
-        [loading, usecases, exportTranslation]
-    );
-
-    const onTableChange = useCallback(({ selection }: TableState<ListItem>) => {
-        setSelection(selection);
-    }, []);
-
-    const openImportDialog = useCallback(async () => {
-        moduleImportRef.current?.openDialog();
-    }, [moduleImportRef]);
-
-    const columns: TableColumn<ListItem>[] = useMemo(
-        () => [
-            {
-                name: "name",
-                text: "Name",
-                sortable: false,
-                getValue: item => (
-                    <div>
-                        {item.name}
-                        {!item.installed && item.rowType === "module" ? (
-                            <AlertIcon tooltip={i18n.t("App is not installed in this instance")} />
-                        ) : null}
-                        {!item.compatible && item.rowType === "module" ? (
-                            <AlertIcon tooltip={i18n.t("Module does not support this DHIS2 version")} />
-                        ) : null}
-                        {item.outdated && item.rowType === "module" ? (
-                            <AlertIcon
-                                tooltip={i18n.t(
-                                    "There's a new version of this module, please reset to default values to update"
-                                )}
-                            />
-                        ) : null}
-                    </div>
-                ),
-            },
-            {
-                name: "id",
-                text: "Code",
-                hidden: true,
-                sortable: false,
-            },
-            {
-                name: "value",
-                text: "Preview",
-                sortable: false,
-                getValue: item => {
-                    return item.value && <StepPreview value={item.value.referenceValue} />;
-                },
-            },
-        ],
-        []
-    );
-
-    const actions: TableAction<ListItem>[] = useMemo(
-        () => [
-            {
-                name: "new-module",
-                text: i18n.t("Add module"),
-                icon: <Icon>add</Icon>,
-                onClick: addModule,
-                isActive: rows => {
-                    return !!tableActions.openCreateModulePage && _.every(rows, item => item.rowType === "module");
-                },
-            },
-            {
-                name: "new-step",
-                text: i18n.t("Add step"),
-                icon: <Icon>add</Icon>,
-                onClick: addStep,
-                isActive: rows => {
-                    return !!tableActions.addStep && _.every(rows, item => item.rowType === "module" && item.editable);
-                },
-            },
-            {
-                name: "new-page",
-                text: i18n.t("Add page"),
-                icon: <Icon>add</Icon>,
-                onClick: addPage,
-                isActive: rows => {
-                    return !!tableActions.addPage && _.every(rows, item => item.rowType === "step" && item.editable);
-                },
-            },
-            {
-                name: "edit-module",
-                text: i18n.t("Edit module"),
-                icon: <Icon>edit</Icon>,
-                onClick: editModule,
-                isActive: rows => {
-                    return (
-                        !!tableActions.openEditModulePage &&
-                        _.every(rows, item => item.rowType === "module" && item.editable)
-                    );
-                },
-            },
-            {
-                name: "clone-module",
-                text: i18n.t("Clone module"),
-                icon: <Icon>content_copy</Icon>,
-                onClick: cloneModule,
-                isActive: rows => {
-                    return (
-                        !!tableActions.openCloneModulePage &&
-                        _.every(rows, item => item.rowType === "module" && item.editable)
-                    );
-                },
-            },
-            {
-                name: "edit-page",
-                text: i18n.t("Edit page"),
-                icon: <Icon>edit</Icon>,
-                onClick: editPage,
-                isActive: rows => {
-                    return (
-                        !!tableActions.editContents && _.every(rows, item => item.rowType === "page" && item.editable)
-                    );
-                },
-            },
-            {
-                name: "edit-step",
-                text: i18n.t("Edit step"),
-                icon: <Icon>edit</Icon>,
-                onClick: editStep,
-                isActive: rows => {
-                    return (
-                        !!tableActions.editContents && _.every(rows, item => item.rowType === "step" && item.editable)
-                    );
-                },
-            },
-            {
-                name: "delete-module",
-                text: i18n.t("Delete module"),
-                icon: <Icon>delete</Icon>,
-                multiple: true,
-                onClick: deleteModules,
-                isActive: rows => {
-                    return (
-                        !!tableActions.deleteModules &&
-                        _.every(rows, item => item.rowType === "module" && item.type !== "core" && item.editable)
-                    );
-                },
-            },
-
-            {
-                name: "delete-step",
-                text: i18n.t("Delete step"),
-                icon: <Icon>delete</Icon>,
-                multiple: true,
-                onClick: deleteStep,
-                isActive: rows => {
-                    return !!tableActions.deleteStep && _.every(rows, item => item.rowType === "step" && item.editable);
-                },
-            },
-            {
-                name: "delete-page",
-                text: i18n.t("Delete page"),
-                icon: <Icon>delete</Icon>,
-                multiple: true,
-                onClick: deletePage,
-                isActive: rows => {
-                    return !!tableActions.deletePage && _.every(rows, item => item.rowType === "page" && item.editable);
-                },
-            },
-            {
-                name: "move-up",
-                text: i18n.t("Move up"),
-                icon: <Icon>arrow_upwards</Icon>,
-                onClick: moveUp,
-                isActive: rows => {
-                    return !!tableActions.swap && _.every(rows, ({ position, editable }) => position !== 0 && editable);
-                },
-            },
-            {
-                name: "move-down",
-                text: i18n.t("Move down"),
-                icon: <Icon>arrow_downwards</Icon>,
-                onClick: moveDown,
-                isActive: rows => {
-                    return (
-                        !!tableActions.swap &&
-                        _.every(rows, ({ position, lastPosition, editable }) => position !== lastPosition && editable)
-                    );
-                },
-            },
-            {
-                name: "install-app",
-                text: i18n.t("Install app"),
-                icon: <GetAppIcon />,
-                onClick: installApp,
-                isActive: rows => {
-                    return (
-                        !!tableActions.installApp && _.every(rows, item => item.rowType === "module" && !item.installed)
-                    );
-                },
-            },
-            {
-                name: "reset-factory-settings",
-                text: i18n.t("Restore to factory settings"),
-                icon: <Icon>rotate_left</Icon>,
-                onClick: resetModules,
-                multiple: true,
-                isActive: rows => {
-                    return (
-                        !!tableActions.resetModules &&
-                        _.every(rows, item => item.rowType === "module" && item.type === "core" && item.editable)
-                    );
-                },
-            },
-            {
-                name: "export-module",
-                text: i18n.t("Export module"),
-                icon: <Icon>cloud_download</Icon>,
-                onClick: exportModule,
-                isActive: rows => {
-                    return _.every(rows, item => item.rowType === "module");
-                },
-                multiple: true,
-            },
-            {
-                name: "export-translations",
-                text: i18n.t("Export JSON translations"),
-                icon: <Icon>translate</Icon>,
-                onClick: exportTranslations,
-                isActive: rows => {
-                    return _.every(rows, item => item.rowType === "module");
-                },
-                multiple: false,
-            },
-        ],
-        [
-            tableActions,
-            editModule,
-            cloneModule,
-            deleteModules,
-            deletePage,
-            deleteStep,
-            moveUp,
-            moveDown,
-            editPage,
-            editStep,
-            installApp,
-            addModule,
-            addPage,
-            addStep,
-            resetModules,
-            exportModule,
-            exportTranslations,
-        ]
-    );
-
-    const globalActions: TableGlobalAction[] = useMemo(
-        () => [
-            {
-                name: "import-modules",
-                text: i18n.t("Import modules"),
-                icon: <Icon>arrow_upward</Icon>,
-                onClick: openImportDialog,
-            },
-            {
-                name: "import-translations",
-                text: i18n.t("Import JSON translations"),
-                icon: <Icon>translate</Icon>,
-                onClick: () => {
-                    translationImportRef.current?.startImport();
-                },
-            },
-        ],
-        [openImportDialog, translationImportRef]
     );
 
     return (
@@ -736,29 +202,6 @@ export const buildListSteps = (model: PartialTrainingModule, steps: TrainingModu
         })),
     }));
 };
-
-const buildChildrenRows = (items: ListItem[]): ListItem[] => {
-    const steps = _.flatMap(items, item => item.steps);
-    const pages = _.flatMap([...items, ...steps], step => step?.pages);
-    return _.compact([...items, ...steps, ...pages]);
-};
-
-const StepPreview: React.FC<{
-    className?: string;
-    value?: string;
-}> = ({ className, value }) => {
-    if (!value) return null;
-
-    return (
-        <StyledModalBody className={className}>
-            <MarkdownViewer source={value} />
-        </StyledModalBody>
-    );
-};
-
-const StyledModalBody = styled(ModalBody)`
-    max-width: 600px;
-`;
 
 const PageWrapper = styled.div`
     .MuiTableRow-root {

--- a/src/webapp/components/module-list-table/ModuleListTable.tsx
+++ b/src/webapp/components/module-list-table/ModuleListTable.tsx
@@ -1,19 +1,5 @@
-import {
-    ConfirmationDialog,
-    ConfirmationDialogProps,
-    ObjectsTable,
-    TableAction,
-    TableColumn,
-    TableGlobalAction,
-    TableSelection,
-    TableState,
-    useLoading,
-    useSnackbar,
-} from "@eyeseetea/d2-ui-components";
-import { Icon } from "@material-ui/core";
-import GetAppIcon from "@material-ui/icons/GetApp";
-import _ from "lodash";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import { ConfirmationDialog, ObjectsTable, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
+import React, { useCallback, useRef } from "react";
 import { FileRejection } from "react-dropzone";
 import styled from "styled-components";
 import { PartialTrainingModule, TrainingModule, TrainingModuleStep } from "../../../domain/entities/TrainingModule";
@@ -22,24 +8,11 @@ import i18n from "../../../utils/i18n";
 import { zipMimeType } from "../../../utils/files";
 import { FlattenUnion } from "../../../utils/flatten-union";
 import { useAppContext } from "../../contexts/app-context";
-import { AlertIcon } from "../alert-icon/AlertIcon";
 import { Dropzone, DropzoneRef } from "../dropzone/Dropzone";
 import { ImportTranslationDialog, ImportTranslationRef } from "../import-translation-dialog/ImportTranslationDialog";
-import { InputDialog, InputDialogProps } from "../input-dialog/InputDialog";
-import { MarkdownEditorDialog, MarkdownEditorDialogProps } from "../markdown-editor/MarkdownEditorDialog";
-import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
-import { ModalBody } from "../modal";
+import { InputDialog } from "../input-dialog/InputDialog";
+import { MarkdownEditorDialog } from "../markdown-editor/MarkdownEditorDialog";
 import { useImportExportTranslation } from "../../hooks/useImportExportTranslation";
-import {
-    addPage,
-    addStep,
-    removePage,
-    removeStep,
-    updateOrder,
-    updateTranslation,
-} from "../../../domain/helpers/TrainingModuleHelpers";
-import { CompositionRoot } from "../../CompositionRoot";
-import { useModuleTableAction } from "./useModuleTableAction";
 import { useModuleList } from "./useModuleList";
 
 export interface ModuleListTableProps {
@@ -47,6 +20,7 @@ export interface ModuleListTableProps {
     refreshRows?: () => Promise<void>;
     onActionButtonClick?: (event: React.MouseEvent<unknown>) => void;
     isLoading?: boolean;
+    tableActions?: ModuleListTableAction;
 }
 
 export const ModuleListTable: React.FC<ModuleListTableProps> = props => {

--- a/src/webapp/components/module-list-table/useModuleList.tsx
+++ b/src/webapp/components/module-list-table/useModuleList.tsx
@@ -1,0 +1,639 @@
+import React, { useCallback, useMemo, useState } from "react";
+import i18n from "../../../utils/i18n";
+import _ from "lodash";
+import {
+    ConfirmationDialogProps,
+    TableAction,
+    TableColumn,
+    TableGlobalAction,
+    TableSelection,
+    TableState,
+    useLoading,
+    useSnackbar,
+} from "@eyeseetea/d2-ui-components";
+import { AlertIcon } from "../alert-icon/AlertIcon";
+import { Icon } from "@material-ui/core";
+import GetAppIcon from "@material-ui/icons/GetApp";
+import { ListItem } from "./ModuleListTable";
+import { useModuleTableAction } from "./useModuleTableAction";
+import { InputDialogProps } from "../input-dialog/InputDialog";
+import { MarkdownEditorDialogProps } from "../markdown-editor/MarkdownEditorDialog";
+import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
+import styled from "styled-components";
+import { ModalBody } from "../modal";
+import { useImportExportTranslation } from "../../hooks/useImportExportTranslation";
+import { useAppContext } from "../../contexts/app-context";
+import { ImportTranslationRef } from "../import-translation-dialog/ImportTranslationDialog";
+
+type UseModuleListProps = {
+    refreshRows: () => Promise<void>;
+    rows: ListItem[];
+    openImportDialog: () => Promise<void>;
+    translationImportRef: React.RefObject<ImportTranslationRef>;
+};
+
+export function useModuleList(props: UseModuleListProps) {
+    const { refreshRows, rows, openImportDialog, translationImportRef } = props;
+
+    const { usecases } = useAppContext();
+    const { exportTranslation } = useImportExportTranslation();
+
+    const loading = useLoading();
+    const snackbar = useSnackbar();
+
+    const [selection, setSelection] = useState<TableSelection[]>([]);
+    const [inputDialogProps, updateInputDialog] = useState<InputDialogProps | null>(null);
+    const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
+    const [markdownDialogProps, updateMarkdownDialog] = useState<MarkdownEditorDialogProps | null>(null);
+
+    const tableActions = useModuleTableAction();
+
+    const deleteModules = useCallback(
+        async (ids: string[]) => {
+            updateDialog({
+                title: i18n.t("Are you sure you want to delete the selected modules?"),
+                description: i18n.t("This action cannot be reversed"),
+                onCancel: () => {
+                    updateDialog(null);
+                },
+                onSave: async () => {
+                    updateDialog(null);
+                    if (!tableActions.deleteModules) return;
+
+                    loading.show(true, i18n.t("Deleting modules"));
+                    await tableActions.deleteModules({ ids });
+                    loading.reset();
+
+                    snackbar.success("Successfully deleted modules");
+                    setSelection([]);
+                    await refreshRows();
+                },
+                cancelText: i18n.t("Cancel"),
+                saveText: i18n.t("Delete modules"),
+            });
+        },
+        [tableActions, loading, refreshRows, snackbar]
+    );
+
+    const deleteStep = useCallback(
+        async (ids: string[]) => {
+            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
+            if (!row || !row.moduleId) return;
+
+            updateDialog({
+                title: i18n.t("Are you sure you want to delete the selected step and its pages?"),
+                description: i18n.t("This action cannot be reversed"),
+                onCancel: () => {
+                    updateDialog(null);
+                },
+                onSave: async () => {
+                    updateDialog(null);
+                    if (!tableActions.deleteStep || !row.moduleId) return;
+                    await tableActions.deleteStep({ id: row.moduleId, step: row.id });
+                    await refreshRows();
+                },
+                cancelText: i18n.t("Cancel"),
+                saveText: i18n.t("Delete step"),
+            });
+        },
+        [tableActions, refreshRows, rows]
+    );
+
+    const deletePage = useCallback(
+        async (ids: string[]) => {
+            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
+            if (!row || !row.moduleId) return;
+
+            updateDialog({
+                title: i18n.t("Are you sure you want to delete the selected page?"),
+                description: i18n.t("This action cannot be reversed"),
+                onCancel: () => {
+                    updateDialog(null);
+                },
+                onSave: async () => {
+                    updateDialog(null);
+                    if (!tableActions.deletePage || !row.moduleId || !row.stepId) return;
+                    await tableActions.deletePage({ id: row.moduleId, step: row.stepId, page: row.id });
+                    await refreshRows();
+                },
+                cancelText: i18n.t("Cancel"),
+                saveText: i18n.t("Delete page"),
+            });
+        },
+        [tableActions, refreshRows, rows]
+    );
+
+    const addModule = useCallback(() => {
+        if (!tableActions.openCreateModulePage) return;
+        tableActions.openCreateModulePage();
+    }, [tableActions]);
+
+    const addStep = useCallback(
+        async (ids: string[]) => {
+            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
+            if (!row || !tableActions.addStep) return;
+
+            updateInputDialog({
+                title: i18n.t("Add new step"),
+                inputLabel: i18n.t("Title *"),
+                onCancel: () => updateInputDialog(null),
+                onSave: async title => {
+                    updateInputDialog(null);
+                    if (!tableActions.addStep) return;
+
+                    await tableActions.addStep({ id: row.id, title });
+                    await refreshRows();
+                },
+            });
+        },
+        [tableActions, rows, refreshRows]
+    );
+
+    const addPage = useCallback(
+        async (ids: string[]) => {
+            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
+            if (!row) return;
+
+            const { uploadFile } = tableActions;
+
+            updateMarkdownDialog({
+                title: i18n.t("Add new page"),
+                markdownPreview: markdown => <StepPreview value={markdown} />,
+                onUpload: uploadFile
+                    ? (data: ArrayBuffer, file: File) => uploadFile({ data, name: file.name })
+                    : undefined,
+                onCancel: () => updateMarkdownDialog(null),
+                onSave: async value => {
+                    updateMarkdownDialog(null);
+                    if (!row.moduleId || !tableActions.addPage) return;
+
+                    await tableActions.addPage({ id: row.moduleId, step: row.id, value });
+                    await refreshRows();
+                },
+            });
+        },
+        [tableActions, rows, refreshRows]
+    );
+
+    const editModule = useCallback(
+        (ids: string[]) => {
+            if (!tableActions.openEditModulePage || !ids[0]) return;
+            tableActions.openEditModulePage({ id: ids[0] });
+        },
+        [tableActions]
+    );
+
+    const cloneModule = useCallback(
+        (ids: string[]) => {
+            if (!tableActions.openCloneModulePage || !ids[0]) return;
+            tableActions.openCloneModulePage({ id: ids[0] });
+        },
+        [tableActions]
+    );
+
+    const moveUp = useCallback(
+        async (ids: string[]) => {
+            const allRows = buildChildrenRows(rows);
+            const rowIndex = _.findIndex(allRows, ({ id }) => id === ids[0]);
+            const row = allRows[rowIndex];
+            if (!tableActions.swap || rowIndex === -1 || rowIndex === 0 || !row) return;
+
+            const { id: prevRowId } = allRows[rowIndex - 1] ?? {};
+            const moduleId = row.rowType === "module" ? row.id : row.moduleId;
+            if (prevRowId && ids[0] && moduleId) {
+                await tableActions.swap({ id: moduleId, type: row.rowType, from: ids[0], to: prevRowId });
+            }
+
+            await refreshRows();
+        },
+        [tableActions, rows, refreshRows]
+    );
+
+    const moveDown = useCallback(
+        async (ids: string[]) => {
+            const allRows = buildChildrenRows(rows);
+            const rowIndex = _.findIndex(allRows, ({ id }) => id === ids[0]);
+            const row = allRows[rowIndex];
+            if (!tableActions.swap || rowIndex === -1 || rowIndex === allRows.length - 1 || !row) return;
+
+            const { id: nextRowId } = allRows[rowIndex + 1] ?? {};
+            const moduleId = row.rowType === "module" ? row.id : row.moduleId;
+            if (nextRowId && ids[0] && moduleId) {
+                await tableActions.swap({ id: moduleId, type: row.rowType, from: ids[0], to: nextRowId });
+            }
+
+            await refreshRows();
+        },
+        [tableActions, rows, refreshRows]
+    );
+
+    const editStep = useCallback(
+        (ids: string[]) => {
+            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
+            if (!row || !row.title) return;
+
+            updateInputDialog({
+                title: i18n.t("Edit step"),
+                inputLabel: i18n.t("Title *"),
+                initialValue: row.title.referenceValue,
+                onCancel: () => updateInputDialog(null),
+                onSave: async value => {
+                    updateInputDialog(null);
+                    if (!tableActions.editContents || !row.title || !row.moduleId) return;
+
+                    await tableActions.editContents({ id: row.moduleId, text: row.title, value });
+                    await refreshRows();
+                },
+            });
+        },
+        [tableActions, rows, refreshRows]
+    );
+
+    const editPage = useCallback(
+        (ids: string[]) => {
+            const row = buildChildrenRows(rows).find(({ id }) => id === ids[0]);
+            if (!row || !row.value) return;
+
+            const { uploadFile } = tableActions;
+
+            updateMarkdownDialog({
+                title: i18n.t("Edit contents of {{name}}", row),
+                initialValue: row.value.referenceValue,
+                markdownPreview: markdown => <StepPreview value={markdown} />,
+                onUpload: uploadFile
+                    ? (data: ArrayBuffer, file: File) => uploadFile({ data, name: file.name })
+                    : undefined,
+                onCancel: () => updateMarkdownDialog(null),
+                onSave: async value => {
+                    updateMarkdownDialog(null);
+                    if (!tableActions.editContents || !row.value || !row.moduleId) return;
+
+                    await tableActions.editContents({ id: row.moduleId, text: row.value, value });
+                    await refreshRows();
+                },
+            });
+        },
+        [tableActions, rows, refreshRows]
+    );
+
+    const installApp = useCallback(
+        async (ids: string[]) => {
+            if (!tableActions.installApp || !ids[0]) return;
+
+            loading.show(true, i18n.t("Installing application"));
+            const installed = await tableActions.installApp({ id: ids[0] });
+            loading.reset();
+
+            if (!installed) {
+                snackbar.error("Error installing app");
+                return;
+            }
+
+            snackbar.success("Successfully installed app");
+            await refreshRows();
+        },
+        [tableActions, snackbar, loading, refreshRows]
+    );
+
+    const resetModules = useCallback(
+        (ids: string[]) => {
+            updateDialog({
+                title: i18n.t("Are you sure you want to reset selected modules to its default value?"),
+                description: i18n.t("This action cannot be reversed."),
+                onCancel: () => updateDialog(null),
+                onSave: async () => {
+                    updateDialog(null);
+                    if (!tableActions.resetModules) return;
+
+                    loading.show(true, i18n.t("Resetting modules to default value"));
+                    await tableActions.resetModules({ ids });
+                    loading.reset();
+
+                    snackbar.success(i18n.t("Successfully resetted modules to default value"));
+                    await refreshRows();
+                },
+                cancelText: i18n.t("Cancel"),
+                saveText: i18n.t("Reset app to factory settings"),
+            });
+        },
+        [tableActions, loading, refreshRows, snackbar]
+    );
+
+    const exportModule = useCallback(
+        async (ids: string[]) => {
+            if (!ids[0]) return;
+            loading.show(true, i18n.t("Exporting module(s)"));
+            await usecases.modules.export(ids);
+            loading.reset();
+        },
+        [loading, usecases]
+    );
+
+    const exportTranslations = useCallback(
+        async (ids: string[]) => {
+            if (!ids[0]) return;
+            loading.show(true, i18n.t("Exporting translations"));
+            await exportTranslation(() => usecases.modules.extractTranslations(ids[0]), ids[0]);
+            loading.reset();
+        },
+        [loading, usecases, exportTranslation]
+    );
+
+    const onTableChange = useCallback(({ selection }: TableState<ListItem>) => {
+        setSelection(selection);
+    }, []);
+
+    const actions: TableAction<ListItem>[] = useMemo(
+        () => [
+            {
+                name: "new-module",
+                text: i18n.t("Add module"),
+                icon: <Icon>add</Icon>,
+                onClick: addModule,
+                isActive: rows => {
+                    return !!tableActions.openCreateModulePage && _.every(rows, item => item.rowType === "module");
+                },
+            },
+            {
+                name: "new-step",
+                text: i18n.t("Add step"),
+                icon: <Icon>add</Icon>,
+                onClick: addStep,
+                isActive: rows => {
+                    return !!tableActions.addStep && _.every(rows, item => item.rowType === "module" && item.editable);
+                },
+            },
+            {
+                name: "new-page",
+                text: i18n.t("Add page"),
+                icon: <Icon>add</Icon>,
+                onClick: addPage,
+                isActive: rows => {
+                    return !!tableActions.addPage && _.every(rows, item => item.rowType === "step" && item.editable);
+                },
+            },
+            {
+                name: "edit-module",
+                text: i18n.t("Edit module"),
+                icon: <Icon>edit</Icon>,
+                onClick: editModule,
+                isActive: rows => {
+                    return (
+                        !!tableActions.openEditModulePage &&
+                        _.every(rows, item => item.rowType === "module" && item.editable)
+                    );
+                },
+            },
+            {
+                name: "clone-module",
+                text: i18n.t("Clone module"),
+                icon: <Icon>content_copy</Icon>,
+                onClick: cloneModule,
+                isActive: rows => {
+                    return (
+                        !!tableActions.openCloneModulePage &&
+                        _.every(rows, item => item.rowType === "module" && item.editable)
+                    );
+                },
+            },
+            {
+                name: "edit-page",
+                text: i18n.t("Edit page"),
+                icon: <Icon>edit</Icon>,
+                onClick: editPage,
+                isActive: rows => {
+                    return (
+                        !!tableActions.editContents && _.every(rows, item => item.rowType === "page" && item.editable)
+                    );
+                },
+            },
+            {
+                name: "edit-step",
+                text: i18n.t("Edit step"),
+                icon: <Icon>edit</Icon>,
+                onClick: editStep,
+                isActive: rows => {
+                    return (
+                        !!tableActions.editContents && _.every(rows, item => item.rowType === "step" && item.editable)
+                    );
+                },
+            },
+            {
+                name: "delete-module",
+                text: i18n.t("Delete module"),
+                icon: <Icon>delete</Icon>,
+                multiple: true,
+                onClick: deleteModules,
+                isActive: rows => {
+                    return (
+                        !!tableActions.deleteModules &&
+                        _.every(rows, item => item.rowType === "module" && item.type !== "core" && item.editable)
+                    );
+                },
+            },
+
+            {
+                name: "delete-step",
+                text: i18n.t("Delete step"),
+                icon: <Icon>delete</Icon>,
+                multiple: true,
+                onClick: deleteStep,
+                isActive: rows => {
+                    return !!tableActions.deleteStep && _.every(rows, item => item.rowType === "step" && item.editable);
+                },
+            },
+            {
+                name: "delete-page",
+                text: i18n.t("Delete page"),
+                icon: <Icon>delete</Icon>,
+                multiple: true,
+                onClick: deletePage,
+                isActive: rows => {
+                    return !!tableActions.deletePage && _.every(rows, item => item.rowType === "page" && item.editable);
+                },
+            },
+            {
+                name: "move-up",
+                text: i18n.t("Move up"),
+                icon: <Icon>arrow_upwards</Icon>,
+                onClick: moveUp,
+                isActive: rows => {
+                    return !!tableActions.swap && _.every(rows, ({ position, editable }) => position !== 0 && editable);
+                },
+            },
+            {
+                name: "move-down",
+                text: i18n.t("Move down"),
+                icon: <Icon>arrow_downwards</Icon>,
+                onClick: moveDown,
+                isActive: rows => {
+                    return (
+                        !!tableActions.swap &&
+                        _.every(rows, ({ position, lastPosition, editable }) => position !== lastPosition && editable)
+                    );
+                },
+            },
+            {
+                name: "install-app",
+                text: i18n.t("Install app"),
+                icon: <GetAppIcon />,
+                onClick: installApp,
+                isActive: rows => {
+                    return (
+                        !!tableActions.installApp && _.every(rows, item => item.rowType === "module" && !item.installed)
+                    );
+                },
+            },
+            {
+                name: "reset-factory-settings",
+                text: i18n.t("Restore to factory settings"),
+                icon: <Icon>rotate_left</Icon>,
+                onClick: resetModules,
+                multiple: true,
+                isActive: rows => {
+                    return (
+                        !!tableActions.resetModules &&
+                        _.every(rows, item => item.rowType === "module" && item.type === "core" && item.editable)
+                    );
+                },
+            },
+            {
+                name: "export-module",
+                text: i18n.t("Export module"),
+                icon: <Icon>cloud_download</Icon>,
+                onClick: exportModule,
+                isActive: rows => {
+                    return _.every(rows, item => item.rowType === "module");
+                },
+                multiple: true,
+            },
+            {
+                name: "export-translations",
+                text: i18n.t("Export JSON translations"),
+                icon: <Icon>translate</Icon>,
+                onClick: exportTranslations,
+                isActive: rows => {
+                    return _.every(rows, item => item.rowType === "module");
+                },
+                multiple: false,
+            },
+        ],
+        [
+            tableActions,
+            editModule,
+            cloneModule,
+            deleteModules,
+            deletePage,
+            deleteStep,
+            moveUp,
+            moveDown,
+            editPage,
+            editStep,
+            installApp,
+            addModule,
+            addPage,
+            addStep,
+            resetModules,
+            exportModule,
+            exportTranslations,
+        ]
+    );
+
+    const globalActions: TableGlobalAction[] = useMemo(
+        () => [
+            {
+                name: "import-modules",
+                text: i18n.t("Import modules"),
+                icon: <Icon>arrow_upward</Icon>,
+                onClick: openImportDialog,
+            },
+            {
+                name: "import-translations",
+                text: i18n.t("Import JSON translations"),
+                icon: <Icon>translate</Icon>,
+                onClick: () => {
+                    translationImportRef.current?.startImport();
+                },
+            },
+        ],
+        [openImportDialog, translationImportRef]
+    );
+
+    const columns = useMemo(() => buildTableColumns(), []);
+
+    return {
+        globalActions,
+        actions,
+        columns,
+        onTableChange,
+        selection,
+        inputDialogProps,
+        confirmDialogProps: dialogProps,
+        markdownDialogProps,
+    };
+}
+
+const buildChildrenRows = (items: ListItem[]): ListItem[] => {
+    const steps = _.flatMap(items, item => item.steps);
+    const pages = _.flatMap([...items, ...steps], step => step?.pages);
+    return _.compact([...items, ...steps, ...pages]);
+};
+
+const StepPreview: React.FC<{
+    className?: string;
+    value?: string;
+}> = ({ className, value }) => {
+    if (!value) return null;
+
+    return (
+        <StyledModalBody className={className}>
+            <MarkdownViewer source={value} />
+        </StyledModalBody>
+    );
+};
+
+function buildTableColumns(): TableColumn<ListItem>[] {
+    return [
+        {
+            name: "name",
+            text: "Name",
+            sortable: false,
+            getValue: item => (
+                <div>
+                    {item.name}
+                    {!item.installed && item.rowType === "module" ? (
+                        <AlertIcon tooltip={i18n.t("App is not installed in this instance")} />
+                    ) : null}
+                    {!item.compatible && item.rowType === "module" ? (
+                        <AlertIcon tooltip={i18n.t("Module does not support this DHIS2 version")} />
+                    ) : null}
+                    {item.outdated && item.rowType === "module" ? (
+                        <AlertIcon
+                            tooltip={i18n.t(
+                                "There's a new version of this module, please reset to default values to update"
+                            )}
+                        />
+                    ) : null}
+                </div>
+            ),
+        },
+        {
+            name: "id",
+            text: "Code",
+            hidden: true,
+            sortable: false,
+        },
+        {
+            name: "value",
+            text: "Preview",
+            sortable: false,
+            getValue: item => {
+                return item.value && <StepPreview value={item.value.referenceValue} />;
+            },
+        },
+    ];
+}
+
+const StyledModalBody = styled(ModalBody)`
+    max-width: 600px;
+`;

--- a/src/webapp/components/module-list-table/useModuleList.tsx
+++ b/src/webapp/components/module-list-table/useModuleList.tsx
@@ -16,7 +16,7 @@ import styled from "styled-components";
 
 import i18n from "../../../utils/i18n";
 import { AlertIcon } from "../alert-icon/AlertIcon";
-import { ListItem, ModuleListTableAction } from "./ModuleListTable";
+import { isListItemPage, ListItem, ModuleListTableAction } from "./ModuleListTable";
 import { useModuleTableAction } from "./useModuleTableAction";
 import { InputDialogProps } from "../input-dialog/InputDialog";
 import { MarkdownEditorDialogProps } from "../markdown-editor/MarkdownEditorDialog";
@@ -25,6 +25,7 @@ import { ModalBody } from "../modal";
 import { useImportExportTranslation } from "../../hooks/useImportExportTranslation";
 import { useAppContext } from "../../contexts/app-context";
 import { ImportTranslationRef } from "../import-translation-dialog/ImportTranslationDialog";
+import { usePagePermissions } from "./usePagePermissions";
 
 type UseModuleListProps = {
     rows: ListItem[];
@@ -57,6 +58,12 @@ export function useModuleList(props: UseModuleListProps) {
         }),
         [moduleTableActions, tableActionsProp]
     );
+
+    const { pagePermissionsDialog, openPagePermissions } = usePagePermissions({
+        rows: buildChildrenRows(rows),
+        onChange: tableActions.editPagePermissions,
+        refreshRows,
+    });
 
     const deleteModules = useCallback(
         async (ids: string[]) => {
@@ -418,6 +425,15 @@ export function useModuleList(props: UseModuleListProps) {
                 },
             },
             {
+                name: "edit-page-sharing-settings",
+                text: i18n.t("Sharing settings"),
+                icon: <Icon>share</Icon>,
+                onClick: openPagePermissions,
+                isActive: rows => {
+                    return _.every(rows, item => isListItemPage(item) && item.editable);
+                },
+            },
+            {
                 name: "edit-step",
                 text: i18n.t("Edit step"),
                 icon: <Icon>edit</Icon>,
@@ -546,6 +562,7 @@ export function useModuleList(props: UseModuleListProps) {
             resetModules,
             exportModule,
             exportTranslations,
+            openPagePermissions,
         ]
     );
 
@@ -580,6 +597,7 @@ export function useModuleList(props: UseModuleListProps) {
         inputDialogProps,
         confirmDialogProps: dialogProps,
         markdownDialogProps,
+        pagePermissionsDialog,
     };
 }
 

--- a/src/webapp/components/module-list-table/useModuleList.tsx
+++ b/src/webapp/components/module-list-table/useModuleList.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react";
-import i18n from "../../../utils/i18n";
 import _ from "lodash";
+import { Icon } from "@material-ui/core";
 import {
     ConfirmationDialogProps,
     TableAction,
@@ -11,15 +11,16 @@ import {
     useLoading,
     useSnackbar,
 } from "@eyeseetea/d2-ui-components";
-import { AlertIcon } from "../alert-icon/AlertIcon";
-import { Icon } from "@material-ui/core";
 import GetAppIcon from "@material-ui/icons/GetApp";
+import styled from "styled-components";
+
+import i18n from "../../../utils/i18n";
+import { AlertIcon } from "../alert-icon/AlertIcon";
 import { ListItem, ModuleListTableAction } from "./ModuleListTable";
 import { useModuleTableAction } from "./useModuleTableAction";
 import { InputDialogProps } from "../input-dialog/InputDialog";
 import { MarkdownEditorDialogProps } from "../markdown-editor/MarkdownEditorDialog";
 import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
-import styled from "styled-components";
 import { ModalBody } from "../modal";
 import { useImportExportTranslation } from "../../hooks/useImportExportTranslation";
 import { useAppContext } from "../../contexts/app-context";

--- a/src/webapp/components/module-list-table/useModuleList.tsx
+++ b/src/webapp/components/module-list-table/useModuleList.tsx
@@ -14,7 +14,7 @@ import {
 import { AlertIcon } from "../alert-icon/AlertIcon";
 import { Icon } from "@material-ui/core";
 import GetAppIcon from "@material-ui/icons/GetApp";
-import { ListItem } from "./ModuleListTable";
+import { ListItem, ModuleListTableAction } from "./ModuleListTable";
 import { useModuleTableAction } from "./useModuleTableAction";
 import { InputDialogProps } from "../input-dialog/InputDialog";
 import { MarkdownEditorDialogProps } from "../markdown-editor/MarkdownEditorDialog";
@@ -26,14 +26,15 @@ import { useAppContext } from "../../contexts/app-context";
 import { ImportTranslationRef } from "../import-translation-dialog/ImportTranslationDialog";
 
 type UseModuleListProps = {
-    refreshRows: () => Promise<void>;
     rows: ListItem[];
+    refreshRows: () => Promise<void>;
     openImportDialog: () => Promise<void>;
     translationImportRef: React.RefObject<ImportTranslationRef>;
+    tableActions?: ModuleListTableAction;
 };
 
 export function useModuleList(props: UseModuleListProps) {
-    const { refreshRows, rows, openImportDialog, translationImportRef } = props;
+    const { refreshRows, rows, openImportDialog, translationImportRef, tableActions: tableActionsProp } = props;
 
     const { usecases } = useAppContext();
     const { exportTranslation } = useImportExportTranslation();
@@ -46,7 +47,15 @@ export function useModuleList(props: UseModuleListProps) {
     const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
     const [markdownDialogProps, updateMarkdownDialog] = useState<MarkdownEditorDialogProps | null>(null);
 
-    const tableActions = useModuleTableAction();
+    const moduleTableActions = useModuleTableAction();
+
+    const tableActions = useMemo(
+        () => ({
+            ...moduleTableActions,
+            ...tableActionsProp,
+        }),
+        [moduleTableActions, tableActionsProp]
+    );
 
     const deleteModules = useCallback(
         async (ids: string[]) => {

--- a/src/webapp/components/module-list-table/useModuleTableAction.ts
+++ b/src/webapp/components/module-list-table/useModuleTableAction.ts
@@ -1,0 +1,69 @@
+import { useAppContext } from "../../contexts/app-context";
+import { useSnackbar } from "@eyeseetea/d2-ui-components";
+import {
+    addPage,
+    addStep,
+    removePage,
+    removeStep,
+    updateOrder,
+    updateTranslation,
+} from "../../../domain/helpers/TrainingModuleHelpers";
+import i18n from "../../../utils/i18n";
+import { ModuleListTableAction } from "./ModuleListTable";
+
+export function useModuleTableAction(): ModuleListTableAction {
+    const { usecases, setAppState } = useAppContext();
+    const snackbar = useSnackbar();
+
+    const getModule = (id: string) => {
+        return usecases.modules.get(id, { autoInstallDefaultModules: true });
+    };
+
+    return {
+        openEditModulePage: ({ id }) => {
+            setAppState({ type: "EDIT_MODULE", module: id });
+        },
+        openCloneModulePage: ({ id }) => {
+            setAppState({ type: "CLONE_MODULE", module: id });
+        },
+        editContents: async ({ id, text, value }) => {
+            const module = await getModule(id);
+            if (module) await usecases.modules.update(updateTranslation(module, text.key, value));
+            else snackbar.error(i18n.t("Unable to update module contents"));
+        },
+        deleteModules: ({ ids }) => usecases.modules.delete(ids),
+        resetModules: ({ ids }) => usecases.modules.resetDefaultValue(ids),
+        swap: async ({ type, id, from, to }) => {
+            if (type === "module") {
+                await usecases.modules.swapOrder(from, to);
+                return;
+            }
+
+            const module = await getModule(id);
+            if (module) await usecases.modules.update(updateOrder(module, from, to));
+            else snackbar.error(i18n.t("Unable to move item"));
+        },
+        uploadFile: ({ data, name }) => usecases.document.uploadFile(data, name),
+        installApp: ({ id }) => usecases.instance.installApp(id),
+        addStep: async ({ id, title }) => {
+            const module = await getModule(id);
+            if (module) await usecases.modules.update(addStep(module, title));
+            else snackbar.error(i18n.t("Unable to add step"));
+        },
+        addPage: async ({ id, step, value }) => {
+            const module = await getModule(id);
+            if (module) await usecases.modules.update(addPage(module, step, value));
+            else snackbar.error(i18n.t("Unable to add page"));
+        },
+        deleteStep: async ({ id, step }) => {
+            const module = await getModule(id);
+            if (module) await usecases.modules.update(removeStep(module, step));
+            else snackbar.error(i18n.t("Unable to remove step"));
+        },
+        deletePage: async ({ id, step, page }) => {
+            const module = await getModule(id);
+            if (module) await usecases.modules.update(removePage(module, step, page));
+            else snackbar.error(i18n.t("Unable to remove page"));
+        },
+    };
+}

--- a/src/webapp/components/module-list-table/useModuleTableAction.ts
+++ b/src/webapp/components/module-list-table/useModuleTableAction.ts
@@ -7,6 +7,7 @@ import {
     removePage,
     removeStep,
     updateOrder,
+    updatePagePermissions,
     updateTranslation,
 } from "../../../domain/helpers/TrainingModuleHelpers";
 import i18n from "../../../utils/i18n";
@@ -39,6 +40,13 @@ export function useModuleTableAction(): ModuleListTableAction {
                 id,
                 module => updateTranslation(module, text.key, value),
                 i18n.t("Unable to update module contents")
+            );
+        },
+        editPagePermissions: async ({ id, page: { id: pageId, permissions } }) => {
+            await withModule(
+                id,
+                module => updatePagePermissions(module, { id: pageId, permissions }),
+                i18n.t("Unable to update page permissions")
             );
         },
         deleteModules: ({ ids }) => usecases.modules.delete(ids),

--- a/src/webapp/components/module-list-table/useModuleTableAction.ts
+++ b/src/webapp/components/module-list-table/useModuleTableAction.ts
@@ -54,7 +54,7 @@ export function useModuleTableAction(): ModuleListTableAction {
         uploadFile: ({ data, name }) => usecases.document.uploadFile(data, name),
         installApp: ({ id }) => usecases.instance.installApp(id),
         addStep: async ({ id, title }) => {
-            await withModule(id, module => addStep(module, title), i18n.t("Unable to update module contents"));
+            await withModule(id, module => addStep(module, title), i18n.t("Unable to add step"));
         },
         addPage: async ({ id, step, value }) => {
             await withModule(id, module => addPage(module, step, value), i18n.t("Unable to add page"));

--- a/src/webapp/components/module-list-table/useModuleTableAction.ts
+++ b/src/webapp/components/module-list-table/useModuleTableAction.ts
@@ -1,5 +1,6 @@
-import { useAppContext } from "../../contexts/app-context";
 import { useSnackbar } from "@eyeseetea/d2-ui-components";
+
+import { useAppContext } from "../../contexts/app-context";
 import {
     addPage,
     addStep,

--- a/src/webapp/components/module-list-table/useModuleTableAction.ts
+++ b/src/webapp/components/module-list-table/useModuleTableAction.ts
@@ -11,13 +11,21 @@ import {
 } from "../../../domain/helpers/TrainingModuleHelpers";
 import i18n from "../../../utils/i18n";
 import { ModuleListTableAction } from "./ModuleListTable";
+import { PartialTrainingModule, TrainingModule } from "../../../domain/entities/TrainingModule";
+import { Maybe } from "../../../types/utils";
 
 export function useModuleTableAction(): ModuleListTableAction {
     const { usecases, setAppState } = useAppContext();
     const snackbar = useSnackbar();
 
-    const getModule = (id: string) => {
-        return usecases.modules.get(id, { autoInstallDefaultModules: true });
+    const withModule = async (
+        id: string,
+        action: (module: PartialTrainingModule) => PartialTrainingModule,
+        message: string
+    ) => {
+        const module = await usecases.modules.get(id, { autoInstallDefaultModules: true });
+        if (module) return usecases.modules.update(action(module));
+        else snackbar.error(message);
     };
 
     return {
@@ -28,9 +36,11 @@ export function useModuleTableAction(): ModuleListTableAction {
             setAppState({ type: "CLONE_MODULE", module: id });
         },
         editContents: async ({ id, text, value }) => {
-            const module = await getModule(id);
-            if (module) await usecases.modules.update(updateTranslation(module, text.key, value));
-            else snackbar.error(i18n.t("Unable to update module contents"));
+            await withModule(
+                id,
+                module => updateTranslation(module, text.key, value),
+                i18n.t("Unable to update module contents")
+            );
         },
         deleteModules: ({ ids }) => usecases.modules.delete(ids),
         resetModules: ({ ids }) => usecases.modules.resetDefaultValue(ids),
@@ -40,31 +50,21 @@ export function useModuleTableAction(): ModuleListTableAction {
                 return;
             }
 
-            const module = await getModule(id);
-            if (module) await usecases.modules.update(updateOrder(module, from, to));
-            else snackbar.error(i18n.t("Unable to move item"));
+            await withModule(id, module => updateOrder(module, from, to), i18n.t("Unable to move item"));
         },
         uploadFile: ({ data, name }) => usecases.document.uploadFile(data, name),
         installApp: ({ id }) => usecases.instance.installApp(id),
         addStep: async ({ id, title }) => {
-            const module = await getModule(id);
-            if (module) await usecases.modules.update(addStep(module, title));
-            else snackbar.error(i18n.t("Unable to add step"));
+            await withModule(id, module => addStep(module, title), i18n.t("Unable to update module contents"));
         },
         addPage: async ({ id, step, value }) => {
-            const module = await getModule(id);
-            if (module) await usecases.modules.update(addPage(module, step, value));
-            else snackbar.error(i18n.t("Unable to add page"));
+            await withModule(id, module => addPage(module, step, value), i18n.t("Unable to add page"));
         },
         deleteStep: async ({ id, step }) => {
-            const module = await getModule(id);
-            if (module) await usecases.modules.update(removeStep(module, step));
-            else snackbar.error(i18n.t("Unable to remove step"));
+            await withModule(id, module => removeStep(module, step), i18n.t("Unable to remove step"));
         },
         deletePage: async ({ id, step, page }) => {
-            const module = await getModule(id);
-            if (module) await usecases.modules.update(removePage(module, step, page));
-            else snackbar.error(i18n.t("Unable to remove page"));
+            await withModule(id, module => removePage(module, step, page), i18n.t("Unable to remove page"));
         },
     };
 }

--- a/src/webapp/components/module-list-table/useModuleTableAction.ts
+++ b/src/webapp/components/module-list-table/useModuleTableAction.ts
@@ -11,8 +11,7 @@ import {
 } from "../../../domain/helpers/TrainingModuleHelpers";
 import i18n from "../../../utils/i18n";
 import { ModuleListTableAction } from "./ModuleListTable";
-import { PartialTrainingModule, TrainingModule } from "../../../domain/entities/TrainingModule";
-import { Maybe } from "../../../types/utils";
+import { PartialTrainingModule } from "../../../domain/entities/TrainingModule";
 
 export function useModuleTableAction(): ModuleListTableAction {
     const { usecases, setAppState } = useAppContext();

--- a/src/webapp/components/permissions-dialog/PermissionsDialog.tsx
+++ b/src/webapp/components/permissions-dialog/PermissionsDialog.tsx
@@ -3,6 +3,7 @@ import React, { useCallback } from "react";
 import { SharedProperties, SharingSetting } from "../../../domain/entities/Ref";
 import i18n from "../../../utils/i18n";
 import { useAppContext } from "../../contexts/app-context";
+import { TableProps } from "@eyeseetea/d2-ui-components/sharing/Table";
 
 export type SharedUpdate = Partial<Pick<SharedProperties, "userAccesses" | "userGroupAccesses" | "publicAccess">>;
 export type PermissionsObject = Required<SharedUpdate> & { name: string };
@@ -73,7 +74,7 @@ export const PermissionsDialog: React.FC<PermissionsDialogProps> = ({
     );
 };
 
-const defaultShowOptions = {
+const defaultShowOptions: TableProps["showOptions"] = {
     dataSharing: false,
     publicSharing: false,
     externalSharing: false,

--- a/src/webapp/components/permissions-dialog/PermissionsDialog.tsx
+++ b/src/webapp/components/permissions-dialog/PermissionsDialog.tsx
@@ -7,13 +7,21 @@ import { useAppContext } from "../../contexts/app-context";
 export type SharedUpdate = Partial<Pick<SharedProperties, "userAccesses" | "userGroupAccesses" | "publicAccess">>;
 export type PermissionsObject = Required<SharedUpdate> & { name: string };
 
-export interface PermissionsDialogProps {
+export type PermissionsDialogProps = {
     object: PermissionsObject;
     onChange: (sharedUpdate: SharedUpdate) => Promise<void>;
     allowPublicAccess?: boolean;
     allowExternalAccess?: boolean;
     onClose: () => void;
-}
+    showOptions?: {
+        publicSharing?: boolean;
+        externalSharing?: boolean;
+        dataSharing?: boolean;
+        permissionPicker?: boolean;
+    };
+};
+
+export type PermissionHandlerProps = Omit<PermissionsDialogProps, "onClose">;
 
 export const PermissionsDialog: React.FC<PermissionsDialogProps> = ({
     object,
@@ -21,9 +29,15 @@ export const PermissionsDialog: React.FC<PermissionsDialogProps> = ({
     allowExternalAccess,
     onClose,
     onChange,
+    showOptions,
 }) => {
     const { usecases } = useAppContext();
     const search = (query: string) => usecases.instance.searchUsers(query);
+
+    const showOptionsProp = {
+        ...defaultShowOptions,
+        ...showOptions,
+    };
 
     const metaObject = {
         meta: { allowPublicAccess, allowExternalAccess },
@@ -32,6 +46,7 @@ export const PermissionsDialog: React.FC<PermissionsDialogProps> = ({
             displayName: object.name,
             userAccesses: mapSharingRules(object.userAccesses),
             userGroupAccesses: mapSharingRules(object.userGroupAccesses),
+            publicAccess: object.publicAccess,
         },
     };
 
@@ -50,18 +65,21 @@ export const PermissionsDialog: React.FC<PermissionsDialogProps> = ({
         <ConfirmationDialog isOpen={true} fullWidth={true} onCancel={onClose} cancelText={i18n.t("Close")}>
             <Sharing
                 meta={metaObject}
-                showOptions={{
-                    dataSharing: false,
-                    publicSharing: false,
-                    externalSharing: false,
-                    permissionPicker: false,
-                }}
+                showOptions={showOptionsProp}
                 onSearch={search}
                 onChange={onUpdateSharingOptions}
             />
         </ConfirmationDialog>
     );
 };
+
+const defaultShowOptions = {
+    dataSharing: false,
+    publicSharing: false,
+    externalSharing: false,
+    permissionPicker: false,
+};
+
 const mapSharingSettings = (settings?: SharingRule[]): SharingSetting[] | undefined => {
     return settings?.map(item => {
         return { id: item.id, access: item.access, name: item.displayName };

--- a/src/webapp/components/permissions-dialog/PermissionsDialog.tsx
+++ b/src/webapp/components/permissions-dialog/PermissionsDialog.tsx
@@ -3,7 +3,6 @@ import React, { useCallback } from "react";
 import { SharedProperties, SharingSetting } from "../../../domain/entities/Ref";
 import i18n from "../../../utils/i18n";
 import { useAppContext } from "../../contexts/app-context";
-import { TableProps } from "@eyeseetea/d2-ui-components/sharing/Table";
 
 export type SharedUpdate = Partial<Pick<SharedProperties, "userAccesses" | "userGroupAccesses" | "publicAccess">>;
 export type PermissionsObject = Required<SharedUpdate> & { name: string };
@@ -36,11 +35,6 @@ export const PermissionsDialog: React.FC<PermissionsDialogProps> = ({
     const { usecases } = useAppContext();
     const search = (query: string) => usecases.instance.searchUsers(query);
 
-    const showOptionsProp = {
-        ...defaultShowOptions,
-        ...showOptions,
-    };
-
     const metaObject = {
         meta: { allowPublicAccess, allowExternalAccess },
         object: {
@@ -49,7 +43,6 @@ export const PermissionsDialog: React.FC<PermissionsDialogProps> = ({
             publicAccess: object.publicAccess,
             userAccesses: mapSharingRules(object.userAccesses),
             userGroupAccesses: mapSharingRules(object.userGroupAccesses),
-            publicAccess: object.publicAccess,
         },
     };
 

--- a/src/webapp/components/step-preview/StepPreview.tsx
+++ b/src/webapp/components/step-preview/StepPreview.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
 import styled from "styled-components";
+
+import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
 import { ModalBody } from "../modal";
 
 export const StepPreview: React.FC<{

--- a/src/webapp/components/step-preview/StepPreview.tsx
+++ b/src/webapp/components/step-preview/StepPreview.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { MarkdownViewer } from "../markdown-viewer/MarkdownViewer";
+import styled from "styled-components";
+import { ModalBody } from "../modal";
+
+export const StepPreview: React.FC<{
+    className?: string;
+    value?: string;
+}> = ({ className, value }) => {
+    if (!value) return null;
+
+    return (
+        <StyledModalBody className={className}>
+            <MarkdownViewer source={value} />
+        </StyledModalBody>
+    );
+};
+
+const StyledModalBody = styled(ModalBody)`
+    max-width: 600px;
+`;

--- a/src/webapp/contexts/AppConfigProvider.tsx
+++ b/src/webapp/contexts/AppConfigProvider.tsx
@@ -9,6 +9,7 @@ interface ConfigContextState {
     hasSettingsAccess: boolean;
     logoInfo: LogoInfo;
     hasLoaded: boolean;
+    reload: () => Promise<void>;
 }
 
 const ConfigContext = createContext<ConfigContextState | null>(null);

--- a/src/webapp/contexts/AppConfigProvider.tsx
+++ b/src/webapp/contexts/AppConfigProvider.tsx
@@ -1,7 +1,8 @@
 import React, { createContext, useContext } from "react";
 import { useAppConfig } from "../hooks/useAppConfig";
 import { LogoInfo } from "../hooks/useAppConfig";
-import { Config, PartialConfig } from "../../domain/entities/Config";
+import { Config } from "../../domain/entities/Config";
+import { PartialConfig } from "../../domain/usecases/SaveConfigUseCase";
 
 interface ConfigContextState {
     appConfig: Config;

--- a/src/webapp/contexts/AppConfigProvider.tsx
+++ b/src/webapp/contexts/AppConfigProvider.tsx
@@ -1,11 +1,11 @@
 import React, { createContext, useContext } from "react";
 import { useAppConfig } from "../hooks/useAppConfig";
 import { LogoInfo } from "../hooks/useAppConfig";
-import { Config } from "../../domain/entities/Config";
+import { Config, PartialConfig } from "../../domain/entities/Config";
 
 interface ConfigContextState {
     appConfig: Config;
-    save: (settings: Partial<Config>) => Promise<void>;
+    save: (settings: PartialConfig) => Promise<void>;
     hasSettingsAccess: boolean;
     logoInfo: LogoInfo;
     hasLoaded: boolean;

--- a/src/webapp/contexts/AppConfigProvider.tsx
+++ b/src/webapp/contexts/AppConfigProvider.tsx
@@ -9,7 +9,7 @@ interface ConfigContextState {
     hasSettingsAccess: boolean;
     logoInfo: LogoInfo;
     hasLoaded: boolean;
-    reload: () => Promise<void>;
+    reloadConfig: () => Promise<Config>;
 }
 
 const ConfigContext = createContext<ConfigContextState | null>(null);

--- a/src/webapp/contexts/app-context.tsx
+++ b/src/webapp/contexts/app-context.tsx
@@ -126,7 +126,7 @@ export interface AppContextState {
     isAdmin: boolean;
 }
 
-interface UseAppContextResult {
+export interface UseAppContextResult {
     appState: AppState;
     setAppState: (appState: AppState | AppStateUpdateMethod) => void;
     routes: AppRoute[];

--- a/src/webapp/contexts/app-context.tsx
+++ b/src/webapp/contexts/app-context.tsx
@@ -7,6 +7,7 @@ import { CompositionRoot } from "../CompositionRoot";
 import { AppState } from "../entities/AppState";
 import { AppRoute } from "../router/AppRoute";
 import { cacheImages } from "../utils/image-cache";
+import { User } from "../../data/entities/User";
 
 const AppContext = React.createContext<AppContextState | null>(null);
 
@@ -15,6 +16,7 @@ export const AppContextProvider: React.FC<AppContextProviderProps> = ({
     routes,
     compositionRoot,
     locale,
+    currentUser,
 }) => {
     const [appState, setAppState] = useState<AppState>({ type: "UNKNOWN" });
     const [modules, setModules] = useState<TrainingModule[]>([]);
@@ -62,6 +64,7 @@ export const AppContextProvider: React.FC<AppContextProviderProps> = ({
                 reload,
                 isLoading,
                 isAdmin,
+                currentUser,
             }}
         >
             {children}
@@ -73,8 +76,19 @@ export function useAppContext(): UseAppContextResult {
     const context = useContext(AppContext);
     if (!context) throw new Error("Context not initialized");
 
-    const { compositionRoot, routes, appState, setAppState, modules, landings, translate, reload, isLoading, isAdmin } =
-        context;
+    const {
+        compositionRoot,
+        routes,
+        appState,
+        setAppState,
+        modules,
+        landings,
+        translate,
+        reload,
+        isLoading,
+        isAdmin,
+        currentUser,
+    } = context;
     const { usecases } = compositionRoot;
     const [module, setCurrentModule] = useState<TrainingModule>();
 
@@ -101,6 +115,7 @@ export function useAppContext(): UseAppContextResult {
         reload,
         isLoading,
         isAdmin,
+        currentUser,
     };
 }
 
@@ -111,6 +126,7 @@ export interface AppContextProviderProps {
     routes: AppRoute[];
     compositionRoot: CompositionRoot;
     locale: string;
+    currentUser: User;
 }
 
 export interface AppContextState {
@@ -124,6 +140,7 @@ export interface AppContextState {
     reload: ReloadMethod;
     isLoading: boolean;
     isAdmin: boolean;
+    currentUser: User;
 }
 
 export interface UseAppContextResult {
@@ -138,4 +155,5 @@ export interface UseAppContextResult {
     reload: ReloadMethod;
     isLoading: boolean;
     isAdmin: boolean;
+    currentUser: User;
 }

--- a/src/webapp/hooks/useAppConfig.ts
+++ b/src/webapp/hooks/useAppConfig.ts
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from "react";
 import _ from "lodash";
 
 import { useAppContext } from "../contexts/app-context";
-import { Config, getDefaultConfig } from "../../domain/entities/Config";
+import { Config, getDefaultConfig, PartialConfig } from "../../domain/entities/Config";
 import { NullabelMaybe } from "../../types/utils";
 
 export function useAppConfig() {
@@ -13,7 +13,7 @@ export function useAppConfig() {
     const logoInfo = useMemo(() => getLogoInfo(appConfig?.logo), [appConfig]);
 
     const save = React.useCallback(
-        (config: Partial<Config>) => {
+        (config: PartialConfig) => {
             return usecases.config.save(config).then(setAppConfig);
         },
         [usecases.config]

--- a/src/webapp/hooks/useAppConfig.ts
+++ b/src/webapp/hooks/useAppConfig.ts
@@ -19,22 +19,30 @@ export function useAppConfig() {
         [usecases.config]
     );
 
-    const reload = React.useCallback(async () => {
-        try {
-            const config = await usecases.config.get();
-            setAppConfig(config);
-            const hasAccess = await usecases.user.checkSettingsPermissions(config);
-            setHasSettingsAccess(hasAccess);
-        } catch (error) {
-            console.error("Error:", error);
-        } finally {
-            setHasLoaded(true);
-        }
-    }, [usecases.config, usecases.user]);
+    const reloadConfig = React.useCallback(
+        async () =>
+            usecases.config.get().then(config => {
+                setAppConfig(config);
+                return config;
+            }),
+        [usecases.config, usecases.user]
+    );
 
     React.useEffect(() => {
-        reload();
-    }, [usecases.config, usecases.user, reload]);
+        const fetchData = async () => {
+            try {
+                const config = await reloadConfig();
+                const hasAccess = await usecases.user.checkSettingsPermissions(config);
+                setHasSettingsAccess(hasAccess);
+            } catch (error) {
+                console.error("Error:", error);
+            } finally {
+                setHasLoaded(true);
+            }
+        };
+
+        fetchData();
+    }, [usecases.config, usecases.user]);
 
     return {
         appConfig,
@@ -42,7 +50,7 @@ export function useAppConfig() {
         hasSettingsAccess,
         logoInfo,
         hasLoaded,
-        reload,
+        reloadConfig,
     };
 }
 

--- a/src/webapp/hooks/useAppConfig.ts
+++ b/src/webapp/hooks/useAppConfig.ts
@@ -19,22 +19,22 @@ export function useAppConfig() {
         [usecases.config]
     );
 
-    React.useEffect(() => {
-        const fetchData = async () => {
-            try {
-                const config = await usecases.config.get();
-                setAppConfig(config);
-                const hasAccess = await usecases.user.checkSettingsPermissions(config);
-                setHasSettingsAccess(hasAccess);
-            } catch (error) {
-                console.error("Error:", error);
-            } finally {
-                setHasLoaded(true);
-            }
-        };
-
-        fetchData();
+    const reload = React.useCallback(async () => {
+        try {
+            const config = await usecases.config.get();
+            setAppConfig(config);
+            const hasAccess = await usecases.user.checkSettingsPermissions(config);
+            setHasSettingsAccess(hasAccess);
+        } catch (error) {
+            console.error("Error:", error);
+        } finally {
+            setHasLoaded(true);
+        }
     }, [usecases.config, usecases.user]);
+
+    React.useEffect(() => {
+        reload();
+    }, [usecases.config, usecases.user, reload]);
 
     return {
         appConfig,
@@ -42,6 +42,7 @@ export function useAppConfig() {
         hasSettingsAccess,
         logoInfo,
         hasLoaded,
+        reload,
     };
 }
 

--- a/src/webapp/hooks/useAppConfig.ts
+++ b/src/webapp/hooks/useAppConfig.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 
 import { useAppContext } from "../contexts/app-context";
 import { Config, getDefaultConfig } from "../../domain/entities/Config";
-import { Maybe } from "../../types/utils";
+import { NullabelMaybe } from "../../types/utils";
 
 export function useAppConfig() {
     const { usecases } = useAppContext();
@@ -50,7 +50,7 @@ export interface LogoInfo {
     logoText: string;
 }
 
-function getLogoInfo(logo?: Maybe<string>): LogoInfo {
+function getLogoInfo(logo?: NullabelMaybe<string>): LogoInfo {
     const logoPath = logo || process.env["REACT_APP_LOGO_PATH"] || "img/logo-eyeseetea.png";
     const filename = logoPath.split("/").reverse()[0] || "";
     const name = filename.substring(0, filename.lastIndexOf("."));

--- a/src/webapp/hooks/useAppConfig.ts
+++ b/src/webapp/hooks/useAppConfig.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 
 import { useAppContext } from "../contexts/app-context";
 import { Config, getDefaultConfig, PartialConfig } from "../../domain/entities/Config";
-import { NullabelMaybe } from "../../types/utils";
+import { Maybe } from "../../types/utils";
 
 export function useAppConfig() {
     const { usecases } = useAppContext();
@@ -50,7 +50,7 @@ export interface LogoInfo {
     logoText: string;
 }
 
-function getLogoInfo(logo?: NullabelMaybe<string>): LogoInfo {
+function getLogoInfo(logo?: Maybe<string>): LogoInfo {
     const logoPath = logo || process.env["REACT_APP_LOGO_PATH"] || "img/logo-eyeseetea.png";
     const filename = logoPath.split("/").reverse()[0] || "";
     const name = filename.substring(0, filename.lastIndexOf("."));

--- a/src/webapp/hooks/useAppConfig.ts
+++ b/src/webapp/hooks/useAppConfig.ts
@@ -2,8 +2,9 @@ import React, { useMemo, useState } from "react";
 import _ from "lodash";
 
 import { useAppContext } from "../contexts/app-context";
-import { Config, getDefaultConfig, PartialConfig } from "../../domain/entities/Config";
+import { Config, getDefaultConfig } from "../../domain/entities/Config";
 import { Maybe } from "../../types/utils";
+import { PartialConfig } from "../../domain/usecases/SaveConfigUseCase";
 
 export function useAppConfig() {
     const { usecases } = useAppContext();
@@ -12,20 +13,21 @@ export function useAppConfig() {
     const [hasLoaded, setHasLoaded] = useState(false);
     const logoInfo = useMemo(() => getLogoInfo(appConfig?.logo), [appConfig]);
 
-    const save = React.useCallback(
-        (config: PartialConfig) => {
-            return usecases.config.save(config).then(setAppConfig);
-        },
-        [usecases.config]
-    );
-
     const reloadConfig = React.useCallback(
         async () =>
             usecases.config.get().then(config => {
                 setAppConfig(config);
                 return config;
             }),
-        [usecases.config, usecases.user]
+        [usecases.config]
+    );
+
+    const save = React.useCallback(
+        async (config: PartialConfig) => {
+            await usecases.config.save(config);
+            await reloadConfig();
+        },
+        [usecases.config, reloadConfig]
     );
 
     React.useEffect(() => {
@@ -42,7 +44,7 @@ export function useAppConfig() {
         };
 
         fetchData();
-    }, [usecases.config, usecases.user]);
+    }, [usecases.config, usecases.user, reloadConfig]);
 
     return {
         appConfig,

--- a/src/webapp/hooks/useLandingNodeActions.ts
+++ b/src/webapp/hooks/useLandingNodeActions.ts
@@ -1,0 +1,111 @@
+import { useCallback } from "react";
+import _ from "lodash";
+import i18n from "../../utils/i18n";
+import { LandingNode } from "../../domain/entities/LandingPage";
+import { useAppContext } from "../contexts/app-context";
+import { LandingPageEditDialogProps } from "../components/landing-page-edit-dialog/LandingPageEditDialog";
+
+const flattenRows = (rows: LandingNode[]): LandingNode[] => {
+    return _.flatMap(rows, row => [row, ...flattenRows(row.children)]);
+};
+
+export function useLandingNodeActions(nodes: LandingNode[], setDialogProps: (props: LandingPageEditDialogProps | undefined) => void) {
+    const { usecases, reload } = useAppContext();
+
+    const doSaveLandingNode = useCallback(
+        async (node: LandingNode) => {
+            setDialogProps(undefined);
+            await usecases.landings.update(node);
+            await reload();
+        },
+        [reload, usecases, setDialogProps]
+    );
+
+    const onAddLandingPage = useCallback(() => {
+        setDialogProps({
+            title: i18n.t("Add Landing Page"),
+            type: "root",
+            parent: "none",
+            order: 0,
+            onCancel: () => setDialogProps(undefined),
+            onSave: doSaveLandingNode,
+        });
+    }, [doSaveLandingNode, setDialogProps]);
+
+    const onAddSection = useCallback(
+        (ids: string[]) => {
+            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            if (!parent) return;
+
+            setDialogProps({
+                title: i18n.t("Add section"),
+                type: "section",
+                parent: parent.id,
+                order: parent.children.length,
+                onCancel: () => setDialogProps(undefined),
+                onSave: doSaveLandingNode,
+            });
+        },
+        [doSaveLandingNode, nodes, setDialogProps]
+    );
+
+    const onAddSubSection = useCallback(
+        (ids: string[]) => {
+            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            if (!parent) return;
+
+            setDialogProps({
+                title: i18n.t("Add sub-section"),
+                type: "sub-section",
+                parent: parent.id,
+                order: parent.children.length,
+                onCancel: () => setDialogProps(undefined),
+                onSave: doSaveLandingNode,
+            });
+        },
+        [doSaveLandingNode, nodes, setDialogProps]
+    );
+
+    const onAddCategory = useCallback(
+        (ids: string[]) => {
+            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            if (!parent) return;
+
+            setDialogProps({
+                title: i18n.t("Add category"),
+                type: "category",
+                parent: parent.id,
+                order: parent.children.length,
+                onCancel: () => setDialogProps(undefined),
+                onSave: doSaveLandingNode,
+            });
+        },
+        [doSaveLandingNode, nodes, setDialogProps]
+    );
+
+    const onEditLandingNode = useCallback(
+        (ids: string[]) => {
+            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            if (!parent) return;
+
+            setDialogProps({
+                title: i18n.t("Edit"),
+                type: parent.type,
+                parent: parent.parent,
+                initialNode: parent,
+                order: parent.order ?? 0,
+                onCancel: () => setDialogProps(undefined),
+                onSave: doSaveLandingNode,
+            });
+        },
+        [doSaveLandingNode, nodes, setDialogProps]
+    );
+
+    return {
+        onAddSection,
+        onAddSubSection,
+        onAddCategory,
+        onEditLandingNode,
+        onAddLandingPage,
+    };
+}

--- a/src/webapp/pages/App.tsx
+++ b/src/webapp/pages/App.tsx
@@ -24,7 +24,8 @@ import { Feedback } from "@eyeseetea/feedback-component";
 import { appConfig } from "../../app-config";
 import { AppConfigProvider } from "../contexts/AppConfigProvider";
 import { D2Api } from "../../types/d2-api";
-import { User } from "../../data/entities/User";
+import { useMigrations } from "../components/migrations/useMigration";
+import Migrations from "../components/migrations/Migrations";
 
 export const routes: AppRoute[] = [
     {
@@ -115,35 +116,46 @@ export const routes: AppRoute[] = [
 
 const App: React.FC<{ locale: string; baseUrl: string }> = ({ locale, baseUrl }) => {
     const [appContextProps, setAppContextProps] = useState<AppContextProviderProps>();
+    const [api] = useState(() => new D2Api({ baseUrl }));
+
+    const migrations = useMigrations(api, appConfig.appKey);
 
     useEffect(() => {
         async function setup() {
-            const compositionRoot = getCompositionRoot(new D2Api({ baseUrl: baseUrl }));
+            const compositionRoot = getCompositionRoot(api);
             const currentUser = await compositionRoot.usecases.user.getCurrent();
 
             setAppContextProps({ compositionRoot, locale, routes, currentUser });
         }
-        setup();
-    }, [baseUrl, locale]);
+
+        if (migrations.state.type === "checked") {
+            setup();
+        }
+    }, [baseUrl, locale, api, migrations.state.type]);
+
     return appContextProps ? (
         <AppContextProvider {...appContextProps}>
             <AppConfigProvider>
                 <StylesProvider injectFirst>
                     <MuiThemeProvider theme={muiTheme}>
                         <OldMuiThemeProvider muiTheme={muiThemeLegacy}>
-                            <SnackbarProvider>
-                                <LoadingProvider>
-                                    <div id="app" className="content">
-                                        <HashRouter>
-                                            <Router baseUrl={baseUrl} />
-                                        </HashRouter>
-                                    </div>
-                                    <Feedback
-                                        options={appConfig.feedback}
-                                        username={appContextProps.currentUser.username}
-                                    />
-                                </LoadingProvider>
-                            </SnackbarProvider>
+                            {migrations.state.type === "pending" ? (
+                                <Migrations migrations={migrations} />
+                            ) : (
+                                <SnackbarProvider>
+                                    <LoadingProvider>
+                                        <div id="app" className="content">
+                                            <HashRouter>
+                                                <Router baseUrl={baseUrl} />
+                                            </HashRouter>
+                                        </div>
+                                        <Feedback
+                                            options={appConfig.feedback}
+                                            username={appContextProps.currentUser.username}
+                                        />
+                                    </LoadingProvider>
+                                </SnackbarProvider>
+                            )}
                         </OldMuiThemeProvider>
                     </MuiThemeProvider>
                 </StylesProvider>

--- a/src/webapp/pages/App.tsx
+++ b/src/webapp/pages/App.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import { HashRouter } from "react-router-dom";
 import i18n from "../../utils/i18n";
 import { getCompositionRoot } from "../CompositionRoot";
-import { AppContextProvider } from "../contexts/app-context";
+import { AppContextProvider, AppContextProviderProps } from "../contexts/app-context";
 import { AppRoute } from "../router/AppRoute";
 import { Router } from "../router/Router";
 import muiThemeLegacy from "../themes/dhis2-legacy.theme";
@@ -24,6 +24,7 @@ import { Feedback } from "@eyeseetea/feedback-component";
 import { appConfig } from "../../app-config";
 import { AppConfigProvider } from "../contexts/AppConfigProvider";
 import { D2Api } from "../../types/d2-api";
+import { User } from "../../data/entities/User";
 
 export const routes: AppRoute[] = [
     {
@@ -113,20 +114,19 @@ export const routes: AppRoute[] = [
 ];
 
 const App: React.FC<{ locale: string; baseUrl: string }> = ({ locale, baseUrl }) => {
-    const compositionRoot = getCompositionRoot(new D2Api({ baseUrl: baseUrl }));
-
-    const [username, setUsername] = useState("");
+    const [appContextProps, setAppContextProps] = useState<AppContextProviderProps>();
 
     useEffect(() => {
         async function setup() {
+            const compositionRoot = getCompositionRoot(new D2Api({ baseUrl: baseUrl }));
             const currentUser = await compositionRoot.usecases.user.getCurrent();
 
-            setUsername(currentUser.username);
+            setAppContextProps({ compositionRoot, locale, routes, currentUser });
         }
         setup();
-    }, [compositionRoot.usecases.user]);
-    return (
-        <AppContextProvider routes={routes} compositionRoot={compositionRoot} locale={locale}>
+    }, [baseUrl, locale]);
+    return appContextProps ? (
+        <AppContextProvider {...appContextProps}>
             <AppConfigProvider>
                 <StylesProvider injectFirst>
                     <MuiThemeProvider theme={muiTheme}>
@@ -138,7 +138,10 @@ const App: React.FC<{ locale: string; baseUrl: string }> = ({ locale, baseUrl })
                                             <Router baseUrl={baseUrl} />
                                         </HashRouter>
                                     </div>
-                                    <Feedback options={appConfig.feedback} username={username} />
+                                    <Feedback
+                                        options={appConfig.feedback}
+                                        username={appContextProps.currentUser.username}
+                                    />
                                 </LoadingProvider>
                             </SnackbarProvider>
                         </OldMuiThemeProvider>
@@ -146,6 +149,8 @@ const App: React.FC<{ locale: string; baseUrl: string }> = ({ locale, baseUrl })
                 </StylesProvider>
             </AppConfigProvider>
         </AppContextProvider>
+    ) : (
+        <h3>Loading...</h3>
     );
 };
 

--- a/src/webapp/pages/App.tsx
+++ b/src/webapp/pages/App.tsx
@@ -133,29 +133,33 @@ const App: React.FC<{ locale: string; baseUrl: string }> = ({ locale, baseUrl })
         }
     }, [baseUrl, locale, api, migrations.state.type]);
 
+    if (migrations.state.type === "pending") {
+        return (
+            <StylesProvider injectFirst>
+                <Migrations migrations={migrations} />
+            </StylesProvider>
+        );
+    }
+
     return appContextProps ? (
         <AppContextProvider {...appContextProps}>
             <AppConfigProvider>
                 <StylesProvider injectFirst>
                     <MuiThemeProvider theme={muiTheme}>
                         <OldMuiThemeProvider muiTheme={muiThemeLegacy}>
-                            {migrations.state.type === "pending" ? (
-                                <Migrations migrations={migrations} />
-                            ) : (
-                                <SnackbarProvider>
-                                    <LoadingProvider>
-                                        <div id="app" className="content">
-                                            <HashRouter>
-                                                <Router baseUrl={baseUrl} />
-                                            </HashRouter>
-                                        </div>
-                                        <Feedback
-                                            options={appConfig.feedback}
-                                            username={appContextProps.currentUser.username}
-                                        />
-                                    </LoadingProvider>
-                                </SnackbarProvider>
-                            )}
+                            <SnackbarProvider>
+                                <LoadingProvider>
+                                    <div id="app" className="content">
+                                        <HashRouter>
+                                            <Router baseUrl={baseUrl} />
+                                        </HashRouter>
+                                    </div>
+                                    <Feedback
+                                        options={appConfig.feedback}
+                                        username={appContextProps.currentUser.username}
+                                    />
+                                </LoadingProvider>
+                            </SnackbarProvider>
                         </OldMuiThemeProvider>
                     </MuiThemeProvider>
                 </StylesProvider>

--- a/src/webapp/pages/home/HomePage.tsx
+++ b/src/webapp/pages/home/HomePage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import CircularProgress from "material-ui/CircularProgress";
 import styled from "styled-components";
 
-import { LandingNode } from "../../../domain/entities/LandingPage";
+import { getUserRootLandings, LandingNode } from "../../../domain/entities/LandingPage";
 import i18n from "../../../utils/i18n";
 import { Modal, ModalContent, ModalTitle } from "../../components/modal";
 import { useAppContext } from "../../contexts/app-context";
@@ -12,11 +12,15 @@ import { MainLandingPage } from "../../components/home/MainLandingPage";
 import { Maybe } from "../../../types/utils";
 
 export const HomePage: React.FC = React.memo(() => {
-    const { setAppState, landings, reload, isLoading } = useAppContext();
+    const { setAppState, landings, reload, isLoading, currentUser } = useAppContext();
     const { hasSettingsAccess } = useAppConfigContext();
 
     const [history, updateHistory] = useState<LandingNode[]>([]);
     const [isLoadingLong, setLoadingLong] = useState<boolean>(false);
+
+    const userLandings = useMemo(() => {
+        return getUserRootLandings(landings, currentUser);
+    }, [currentUser, landings]);
 
     const openSettings = useCallback(() => {
         setAppState({ type: "SETTINGS" });
@@ -59,9 +63,12 @@ export const HomePage: React.FC = React.memo(() => {
 
     const currentPage = useMemo<Maybe<LandingNode>>(() => {
         if (history[0]) return history[0];
-        return landings.length > 1 ? undefined : landings[0];
-    }, [history, landings]);
+        return userLandings.length > 1 ? undefined : userLandings[0];
+    }, [history, userLandings]);
 
+    // show empty main landing if no user landings
+    // similar to how it looks like upon initial install
+    const isMainLandingVisible = userLandings.length > 1 || userLandings.length === 0;
     const isRoot = history.length === 0;
 
     useEffect(() => {
@@ -104,8 +111,8 @@ export const HomePage: React.FC = React.memo(() => {
                     />
                 )}
 
-                {!isLoading && !currentPage && landings.length > 1 && (
-                    <MainLandingPage openPage={openPage} landingNodes={landings} />
+                {!isLoading && !currentPage && isMainLandingVisible && (
+                    <MainLandingPage openPage={openPage} landingNodes={userLandings} />
                 )}
             </ContentWrapper>
         </StyledModal>

--- a/src/webapp/pages/home/HomePage.tsx
+++ b/src/webapp/pages/home/HomePage.tsx
@@ -8,6 +8,8 @@ import { Modal, ModalContent, ModalTitle } from "../../components/modal";
 import { useAppContext } from "../../contexts/app-context";
 import { useAppConfigContext } from "../../contexts/AppConfigProvider";
 import { HomePageContent } from "../../components/home/HomePageContent";
+import { MainLandingPage } from "../../components/home/MainLandingPage";
+import { Maybe } from "../../../types/utils";
 
 export const HomePage: React.FC = React.memo(() => {
     const { setAppState, landings, reload, isLoading } = useAppContext();
@@ -55,8 +57,9 @@ export const HomePage: React.FC = React.memo(() => {
         [setAppState]
     );
 
-    const currentPage = useMemo<LandingNode | undefined>(() => {
-        return history[0] ?? landings[0];
+    const currentPage = useMemo<Maybe<LandingNode>>(() => {
+        if (history[0]) return history[0];
+        return landings.length > 1 ? undefined : landings[0];
     }, [history, landings]);
 
     const isRoot = history.length === 0;
@@ -83,21 +86,27 @@ export const HomePage: React.FC = React.memo(() => {
             allowDrag={true}
         >
             <ContentWrapper>
-                {isLoading ? (
+                {isLoading && (
                     <React.Fragment>
                         <Progress color={"white"} size={65} />
                         {isLoadingLong ? (
                             <p>{i18n.t("First load can take a couple of minutes, please wait...")}</p>
                         ) : null}
                     </React.Fragment>
-                ) : currentPage ? (
+                )}
+
+                {!isLoading && currentPage && (
                     <HomePageContent
                         isRoot={isRoot}
                         loadModule={loadModule}
                         currentPage={currentPage}
                         openPage={openPage}
                     />
-                ) : null}
+                )}
+
+                {!isLoading && !currentPage && landings.length > 1 && (
+                    <MainLandingPage openPage={openPage} landingNodes={landings} />
+                )}
             </ContentWrapper>
         </StyledModal>
     );

--- a/src/webapp/pages/settings/CreateButton.tsx
+++ b/src/webapp/pages/settings/CreateButton.tsx
@@ -4,6 +4,7 @@ import { SpeedDial, SpeedDialAction, SpeedDialIcon } from "@material-ui/lab";
 
 import i18n from "../../../utils/i18n";
 import { useAppContext } from "../../contexts/app-context";
+import styled from "styled-components";
 
 export interface CreateButtonProps {
     onAddLandingPage: () => void;
@@ -21,13 +22,7 @@ export const CreateButton: React.FC<CreateButtonProps> = props => {
 
     return (
         <>
-            <SpeedDial
-                open={isOpen}
-                onClick={open}
-                style={styles.speedDial}
-                ariaLabel={i18n.t("Create")}
-                icon={<SpeedDialIcon />}
-            >
+            <StyledSpeedDial open={isOpen} onClick={open} ariaLabel={i18n.t("Create")} icon={<SpeedDialIcon />}>
                 <SpeedDialAction
                     onClick={onAddModule}
                     tooltipOpen
@@ -41,14 +36,16 @@ export const CreateButton: React.FC<CreateButtonProps> = props => {
                     icon={<Description />}
                     tooltipTitle={i18n.t("Landing Page")}
                 />
-            </SpeedDial>
+            </StyledSpeedDial>
         </>
     );
 };
 
-const styles = {
-    speedDial: { position: "fixed" as const, bottom: 16, right: 16 },
-};
+const StyledSpeedDial = styled(SpeedDial)`
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+`;
 
 function useOpenAction() {
     const [isOpen, setOpen] = React.useState(false);

--- a/src/webapp/pages/settings/CreateButton.tsx
+++ b/src/webapp/pages/settings/CreateButton.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback } from "react";
+import i18n from "../../../utils/i18n";
+import { SpeedDial, SpeedDialAction, SpeedDialIcon } from "@material-ui/lab";
+import { useAppContext } from "../../contexts/app-context";
+import { Description, OpenInBrowser } from "@material-ui/icons";
+
+export interface CreateButtonProps {
+    onAddLandingPage: () => void;
+}
+
+export const CreateButton: React.FC<CreateButtonProps> = props => {
+    const { onAddLandingPage } = props;
+
+    const { setAppState } = useAppContext();
+    const onAddModule = useCallback(() => {
+        setAppState({ type: "CREATE_MODULE" });
+    }, [setAppState]);
+
+    const [isOpen, open] = useOpenAction();
+
+    return (
+        <>
+            <SpeedDial
+                open={isOpen}
+                onClick={open}
+                style={styles.speedDial}
+                ariaLabel={i18n.t("Create")}
+                icon={<SpeedDialIcon />}
+            >
+                <SpeedDialAction
+                    onClick={onAddModule}
+                    tooltipOpen
+                    icon={<OpenInBrowser />}
+                    tooltipTitle={i18n.t("Module")}
+                />
+
+                <SpeedDialAction
+                    onClick={onAddLandingPage}
+                    tooltipOpen
+                    icon={<Description />}
+                    tooltipTitle={i18n.t("Landing Page")}
+                />
+            </SpeedDial>
+        </>
+    );
+};
+
+const styles = {
+    speedDial: { position: "fixed" as const, bottom: 16, right: 16 },
+};
+
+function useOpenAction() {
+    const [isOpen, setOpen] = React.useState(false);
+    const open = React.useCallback(() => setOpen(prev => !prev), []);
+    return [isOpen, open] as const;
+}

--- a/src/webapp/pages/settings/CreateButton.tsx
+++ b/src/webapp/pages/settings/CreateButton.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback } from "react";
-import i18n from "../../../utils/i18n";
-import { SpeedDial, SpeedDialAction, SpeedDialIcon } from "@material-ui/lab";
-import { useAppContext } from "../../contexts/app-context";
 import { Description, OpenInBrowser } from "@material-ui/icons";
+import { SpeedDial, SpeedDialAction, SpeedDialIcon } from "@material-ui/lab";
+
+import i18n from "../../../utils/i18n";
+import { useAppContext } from "../../contexts/app-context";
 
 export interface CreateButtonProps {
     onAddLandingPage: () => void;

--- a/src/webapp/pages/settings/SettingsConfig.tsx
+++ b/src/webapp/pages/settings/SettingsConfig.tsx
@@ -1,26 +1,32 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 
 import { FormGroup, Icon, ListItem, ListItemIcon, ListItemText } from "@material-ui/core";
 import i18n from "../../../utils/i18n";
 import { useAppConfigContext } from "../../contexts/AppConfigProvider";
-import { Maybe } from "../../../types/utils";
 import { NamedRef } from "../../../domain/entities/Ref";
 import { useAppContext } from "../../contexts/app-context";
 import { ConfirmationDialog, ConfirmationDialogProps, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
 import { TrainingModule } from "../../../domain/entities/TrainingModule";
 import { LandingNode } from "../../../domain/entities/LandingPage";
-import { CustomizeSettingsDialog } from "../../components/customize-settings-dialog/CustomizeSettingsDialog";
-import { buildSharingDescription } from "../../utils/sharing-settings";
+import {
+    CustomizeSettingsDialog,
+    CustomizeSettingsSaveForm,
+} from "../../components/customize-settings-dialog/CustomizeSettingsDialog";
+import { buildSettingsPermissionDialogProps, buildSharingDescription } from "../../utils/sharing-settings";
+import {
+    PermissionHandlerProps,
+    PermissionsDialog,
+    SharedUpdate,
+} from "../../components/permissions-dialog/PermissionsDialog";
 
 type SettingsConfigProps = {
-    setPermissionsType: (type: Maybe<"settings">) => void;
     modules: TrainingModule[];
     landings: LandingNode[];
 };
 
 export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
-    const { setPermissionsType, modules, landings } = props;
+    const { modules, landings } = props;
     const { usecases, isAdmin, isLoading } = useAppContext();
     const { appConfig, save, hasLoaded, logoInfo } = useAppConfigContext();
     const snackbar = useSnackbar();
@@ -29,31 +35,25 @@ export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
     const [danglingDocuments, setDanglingDocuments] = useState<NamedRef[]>([]);
     const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
     const [showCustomSettings, setShowCustomSettings] = useState(false);
+    const [showPermissionDialog, setShowPermissionDialog] = useState(false);
 
-    const toggleShowAllModules = useCallback(() => {
-        return save({
-            showAllModules: !appConfig.showAllModules,
-        });
-    }, [appConfig, save]);
-
-    const openSettingsPermission = useCallback(() => {
-        console.log("openSettingsPermission");
-        setPermissionsType("settings");
-    }, [setPermissionsType]);
-
+    const closePermissionsDialog = useCallback(() => setShowPermissionDialog(false), []);
+    const openSettingsPermission = useCallback(() => setShowPermissionDialog(true), []);
     const openCustomizeSettingsDialog = useCallback(() => setShowCustomSettings(true), []);
-
-    const closeCustomSettingsDialog = useCallback(() => {
-        setShowCustomSettings(false);
-    }, []);
+    const closeCustomSettingsDialog = useCallback(() => setShowCustomSettings(false), []);
 
     const saveCustomSettings = useCallback(
-        async data => {
+        async (data: Partial<CustomizeSettingsSaveForm>) => {
             await save(data);
             closeCustomSettingsDialog();
         },
         [save, closeCustomSettingsDialog]
     );
+    const toggleShowAllModules = useCallback(() => {
+        return save({
+            showAllModules: !appConfig.showAllModules,
+        });
+    }, [appConfig, save]);
 
     const cleanUpDanglingDocuments = useCallback(async () => {
         updateDialog({
@@ -80,6 +80,24 @@ export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
         });
     }, [danglingDocuments, loading, snackbar, usecases]);
 
+    const permissionsDialogProps: PermissionHandlerProps = useMemo(
+        () => ({
+            object: buildSettingsPermissionDialogProps({
+                permissions: appConfig.settingsPermissions,
+                name: "Access to settings",
+            }),
+            onChange: async ({ userAccesses, userGroupAccesses }: SharedUpdate) => {
+                return save({
+                    settingsPermissions: {
+                        users: userAccesses?.map(({ id, name }) => ({ id, name })),
+                        userGroups: userGroupAccesses?.map(({ id, name }) => ({ id, name })),
+                    },
+                });
+            },
+        }),
+        [appConfig, save]
+    );
+
     useEffect(() => {
         if (!hasLoaded || isLoading) return;
         const data = [...modules, ...landings, appConfig];
@@ -88,6 +106,7 @@ export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
 
     return (
         <>
+            {showPermissionDialog && <PermissionsDialog onClose={closePermissionsDialog} {...permissionsDialogProps} />}
             {dialogProps && <ConfirmationDialog isOpen={true} maxWidth={"lg"} fullWidth={true} {...dialogProps} />}
             {showCustomSettings && (
                 <CustomizeSettingsDialog

--- a/src/webapp/pages/settings/SettingsConfig.tsx
+++ b/src/webapp/pages/settings/SettingsConfig.tsx
@@ -11,16 +11,16 @@ import { ConfirmationDialog, ConfirmationDialogProps, useLoading, useSnackbar } 
 import { TrainingModule } from "../../../domain/entities/TrainingModule";
 import { LandingNode } from "../../../domain/entities/LandingPage";
 import { CustomizeSettingsDialog } from "../../components/customize-settings-dialog/CustomizeSettingsDialog";
+import { buildSharingDescription } from "../../utils/sharing-settings";
 
 type SettingsConfigProps = {
     setPermissionsType: (type: Maybe<"settings">) => void;
-    buildSharingDescription: (props: Maybe<{ users?: NamedRef[]; userGroups?: NamedRef[] }>) => string;
     modules: TrainingModule[];
     landings: LandingNode[];
 };
 
 export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
-    const { setPermissionsType, buildSharingDescription, modules, landings } = props;
+    const { setPermissionsType, modules, landings } = props;
     const { usecases, isAdmin, isLoading } = useAppContext();
     const { appConfig, save, hasLoaded, logoInfo } = useAppConfigContext();
     const snackbar = useSnackbar();
@@ -37,6 +37,7 @@ export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
     }, [appConfig, save]);
 
     const openSettingsPermission = useCallback(() => {
+        console.log("openSettingsPermission");
         setPermissionsType("settings");
     }, [setPermissionsType]);
 
@@ -98,7 +99,7 @@ export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
             )}
 
             <Group row={true}>
-                <ListItem button onClick={() => openSettingsPermission}>
+                <ListItem button onClick={openSettingsPermission}>
                     <ListItemIcon>
                         <Icon>settings</Icon>
                     </ListItemIcon>

--- a/src/webapp/pages/settings/SettingsConfig.tsx
+++ b/src/webapp/pages/settings/SettingsConfig.tsx
@@ -149,7 +149,7 @@ export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
                         <Icon>format_shapes</Icon>
                     </ListItemIcon>
                     <ListItemText
-                        primary={i18n.t("Customize the main landing page")}
+                        primary={i18n.t("Customize landing page selection")}
                         secondary={i18n.t("Update the logo or content")}
                     />
                 </ListItem>

--- a/src/webapp/pages/settings/SettingsConfig.tsx
+++ b/src/webapp/pages/settings/SettingsConfig.tsx
@@ -149,7 +149,7 @@ export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
                         <Icon>format_shapes</Icon>
                     </ListItemIcon>
                     <ListItemText
-                        primary={i18n.t("Customize the landing page")}
+                        primary={i18n.t("Customize the main landing page")}
                         secondary={i18n.t("Update the logo or content")}
                     />
                 </ListItem>

--- a/src/webapp/pages/settings/SettingsConfig.tsx
+++ b/src/webapp/pages/settings/SettingsConfig.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
-
 import { FormGroup, Icon, ListItem, ListItemIcon, ListItemText } from "@material-ui/core";
+import { ConfirmationDialog, ConfirmationDialogProps, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
+
 import i18n from "../../../utils/i18n";
 import { useAppConfigContext } from "../../contexts/AppConfigProvider";
 import { NamedRef } from "../../../domain/entities/Ref";
 import { useAppContext } from "../../contexts/app-context";
-import { ConfirmationDialog, ConfirmationDialogProps, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
 import { TrainingModule } from "../../../domain/entities/TrainingModule";
 import { LandingNode } from "../../../domain/entities/LandingPage";
 import {

--- a/src/webapp/pages/settings/SettingsConfig.tsx
+++ b/src/webapp/pages/settings/SettingsConfig.tsx
@@ -9,10 +9,7 @@ import { NamedRef } from "../../../domain/entities/Ref";
 import { useAppContext } from "../../contexts/app-context";
 import { TrainingModule } from "../../../domain/entities/TrainingModule";
 import { LandingNode } from "../../../domain/entities/LandingPage";
-import {
-    CustomizeSettingsDialog,
-    CustomizeSettingsSaveForm,
-} from "../../components/customize-settings-dialog/CustomizeSettingsDialog";
+import { CustomizeSettingsDialog } from "../../components/customize-settings-dialog/CustomizeSettingsDialog";
 import { buildSettingsPermissionDialogProps, buildSharingDescription } from "../../utils/sharing-settings";
 import {
     PermissionHandlerProps,
@@ -28,7 +25,7 @@ type SettingsConfigProps = {
 export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
     const { modules, landings } = props;
     const { usecases, isAdmin, isLoading } = useAppContext();
-    const { appConfig, save, hasLoaded, logoInfo } = useAppConfigContext();
+    const { appConfig, save, hasLoaded } = useAppConfigContext();
     const snackbar = useSnackbar();
     const loading = useLoading();
 
@@ -42,13 +39,6 @@ export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
     const openCustomizeSettingsDialog = useCallback(() => setShowCustomSettings(true), []);
     const closeCustomSettingsDialog = useCallback(() => setShowCustomSettings(false), []);
 
-    const saveCustomSettings = useCallback(
-        async (data: Partial<CustomizeSettingsSaveForm>) => {
-            await save(data);
-            closeCustomSettingsDialog();
-        },
-        [save, closeCustomSettingsDialog]
-    );
     const toggleShowAllModules = useCallback(() => {
         return save({
             showAllModules: !appConfig.showAllModules,
@@ -108,14 +98,7 @@ export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
         <>
             {showPermissionDialog && <PermissionsDialog onClose={closePermissionsDialog} {...permissionsDialogProps} />}
             {dialogProps && <ConfirmationDialog isOpen={true} maxWidth={"lg"} fullWidth={true} {...dialogProps} />}
-            {showCustomSettings && (
-                <CustomizeSettingsDialog
-                    onSave={saveCustomSettings}
-                    customText={appConfig?.customText ?? emptyObject}
-                    onClose={closeCustomSettingsDialog}
-                    logo={logoInfo.logoPath}
-                />
-            )}
+            {showCustomSettings && <CustomizeSettingsDialog onClose={closeCustomSettingsDialog} />}
 
             <Group row={true}>
                 <ListItem button onClick={openSettingsPermission}>
@@ -175,8 +158,6 @@ export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
         </>
     );
 };
-
-const emptyObject = {};
 
 const Group = styled(FormGroup)`
     margin-bottom: 35px;

--- a/src/webapp/pages/settings/SettingsConfig.tsx
+++ b/src/webapp/pages/settings/SettingsConfig.tsx
@@ -1,0 +1,164 @@
+import React, { useCallback, useEffect, useState } from "react";
+import styled from "styled-components";
+
+import { FormGroup, Icon, ListItem, ListItemIcon, ListItemText } from "@material-ui/core";
+import i18n from "../../../utils/i18n";
+import { useAppConfigContext } from "../../contexts/AppConfigProvider";
+import { Maybe } from "../../../types/utils";
+import { NamedRef } from "../../../domain/entities/Ref";
+import { useAppContext } from "../../contexts/app-context";
+import { ConfirmationDialog, ConfirmationDialogProps, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
+import { TrainingModule } from "../../../domain/entities/TrainingModule";
+import { LandingNode } from "../../../domain/entities/LandingPage";
+import { CustomizeSettingsDialog } from "../../components/customize-settings-dialog/CustomizeSettingsDialog";
+
+type SettingsConfigProps = {
+    setPermissionsType: (type: Maybe<"settings">) => void;
+    buildSharingDescription: (props: Maybe<{ users?: NamedRef[]; userGroups?: NamedRef[] }>) => string;
+    modules: TrainingModule[];
+    landings: LandingNode[];
+};
+
+export const SettingsConfig: React.FC<SettingsConfigProps> = props => {
+    const { setPermissionsType, buildSharingDescription, modules, landings } = props;
+    const { usecases, isAdmin, isLoading } = useAppContext();
+    const { appConfig, save, hasLoaded, logoInfo } = useAppConfigContext();
+    const snackbar = useSnackbar();
+    const loading = useLoading();
+
+    const [danglingDocuments, setDanglingDocuments] = useState<NamedRef[]>([]);
+    const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
+    const [showCustomSettings, setShowCustomSettings] = useState(false);
+
+    const toggleShowAllModules = useCallback(() => {
+        return save({
+            showAllModules: !appConfig.showAllModules,
+        });
+    }, [appConfig, save]);
+
+    const openSettingsPermission = useCallback(() => {
+        setPermissionsType("settings");
+    }, [setPermissionsType]);
+
+    const openCustomizeSettingsDialog = useCallback(() => setShowCustomSettings(true), []);
+
+    const closeCustomSettingsDialog = useCallback(() => {
+        setShowCustomSettings(false);
+    }, []);
+
+    const saveCustomSettings = useCallback(
+        async data => {
+            await save(data);
+            closeCustomSettingsDialog();
+        },
+        [save, closeCustomSettingsDialog]
+    );
+
+    const cleanUpDanglingDocuments = useCallback(async () => {
+        updateDialog({
+            title: i18n.t("Clean-up unused documents"),
+            description: (
+                <ul>
+                    {danglingDocuments.map(item => (
+                        <li key={item.id}>{`${item.id} ${item.name}`}</li>
+                    ))}
+                </ul>
+            ),
+            onCancel: () => updateDialog(null),
+            onSave: async () => {
+                loading.show(true, i18n.t("Deleting dangling documents"));
+
+                await usecases.document.delete(danglingDocuments.map(({ id }) => id));
+                setDanglingDocuments([]);
+
+                snackbar.success(i18n.t("Deleted dangling documents"));
+                loading.reset();
+                updateDialog(null);
+            },
+            saveText: i18n.t("Proceed"),
+        });
+    }, [danglingDocuments, loading, snackbar, usecases]);
+
+    useEffect(() => {
+        if (!hasLoaded || isLoading) return;
+        const data = [...modules, ...landings, appConfig];
+        usecases.document.listDangling(data).then(setDanglingDocuments);
+    }, [usecases, modules, landings, appConfig, isLoading, hasLoaded]);
+
+    return (
+        <>
+            {dialogProps && <ConfirmationDialog isOpen={true} maxWidth={"lg"} fullWidth={true} {...dialogProps} />}
+            {showCustomSettings && (
+                <CustomizeSettingsDialog
+                    onSave={saveCustomSettings}
+                    customText={appConfig?.customText ?? emptyObject}
+                    onClose={closeCustomSettingsDialog}
+                    logo={logoInfo.logoPath}
+                />
+            )}
+
+            <Group row={true}>
+                <ListItem button onClick={() => openSettingsPermission}>
+                    <ListItemIcon>
+                        <Icon>settings</Icon>
+                    </ListItemIcon>
+                    <ListItemText
+                        primary={i18n.t("Access to Settings")}
+                        secondary={buildSharingDescription(appConfig.settingsPermissions)}
+                    />
+                </ListItem>
+
+                <ListItem button onClick={toggleShowAllModules}>
+                    {appConfig.showAllModules}
+
+                    <ListItemIcon>
+                        <Icon>{appConfig.showAllModules ? "visibility" : "visibility_off"}</Icon>
+                    </ListItemIcon>
+                    <ListItemText
+                        primary={i18n.t("Show list with modules on main landing page")}
+                        secondary={
+                            appConfig.showAllModules
+                                ? i18n.t("A list with all the existing modules is visible")
+                                : i18n.t("The list with all the existing  modules is hidden")
+                        }
+                    />
+                </ListItem>
+
+                <ListItem button onClick={openCustomizeSettingsDialog}>
+                    <ListItemIcon>
+                        <Icon>format_shapes</Icon>
+                    </ListItemIcon>
+                    <ListItemText
+                        primary={i18n.t("Customize the landing page")}
+                        secondary={i18n.t("Update the logo or content")}
+                    />
+                </ListItem>
+
+                {isAdmin && (
+                    <ListItem button disabled={danglingDocuments.length === 0} onClick={cleanUpDanglingDocuments}>
+                        <ListItemIcon>
+                            <Icon>delete_forever</Icon>
+                        </ListItemIcon>
+                        <ListItemText
+                            primary={i18n.t("Clean-up unused documents")}
+                            secondary={
+                                danglingDocuments.length === 0
+                                    ? i18n.t("There are no unused documents to clean")
+                                    : i18n.t("There are {{total}} documents available to clean", {
+                                          total: danglingDocuments.length,
+                                      })
+                            }
+                        />
+                    </ListItem>
+                )}
+            </Group>
+        </>
+    );
+};
+
+const emptyObject = {};
+
+const Group = styled(FormGroup)`
+    margin-bottom: 35px;
+    margin-left: 0;
+`;

--- a/src/webapp/pages/settings/SettingsPage.tsx
+++ b/src/webapp/pages/settings/SettingsPage.tsx
@@ -26,11 +26,11 @@ export const SettingsPage: React.FC = () => {
     }, [setAppState]);
 
     const updateSettingsPermissions = useCallback(
-        async ({ userAccesses = [], userGroupAccesses = [] }: SharedUpdate) => {
+        async ({ userAccesses, userGroupAccesses }: SharedUpdate) => {
             return save({
                 settingsPermissions: {
-                    users: userAccesses.map(({ id, name }) => ({ id, name })),
-                    userGroups: userGroupAccesses.map(({ id, name }) => ({ id, name })),
+                    users: userAccesses?.map(({ id, name }) => ({ id, name })),
+                    userGroups: userGroupAccesses?.map(({ id, name }) => ({ id, name })),
                 },
             });
         },

--- a/src/webapp/pages/settings/SettingsPage.tsx
+++ b/src/webapp/pages/settings/SettingsPage.tsx
@@ -1,17 +1,6 @@
-import { ConfirmationDialog, ConfirmationDialogProps, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
-import { NamedRef } from "../../../domain/entities/Ref";
-import {
-    addPage,
-    addStep,
-    removePage,
-    removeStep,
-    updateOrder,
-    updateTranslation,
-} from "../../../domain/helpers/TrainingModuleHelpers";
 import i18n from "../../../utils/i18n";
-import { ComponentParameter, Maybe } from "../../../types/utils";
 import { LandingPageListTable } from "../../components/landing-page-list-table/LandingPageListTable";
 import { buildListModules, ModuleListTable } from "../../components/module-list-table/ModuleListTable";
 import { PageHeader } from "../../components/page-header/PageHeader";
@@ -22,13 +11,13 @@ import { useAppConfigContext } from "../../contexts/AppConfigProvider";
 import { CreateButton } from "./CreateButton";
 import { LandingPageEditDialog } from "../../components/landing-page-edit-dialog/LandingPageEditDialog";
 import { SettingsConfig } from "./SettingsConfig";
+import { useLandingNodeDialog } from "./useLandingNodeDialog";
 
 export const SettingsPage: React.FC = () => {
-    const { modules, landings, reload, usecases, setAppState, isLoading } = useAppContext();
+    const { modules, landings, reload, setAppState, isLoading } = useAppContext();
 
     const { appConfig, save } = useAppConfigContext();
-
-    const snackbar = useSnackbar();
+    const { landingNodeDetailsDialog, onAddLandingPage, ...actionsDialog } = useLandingNodeDialog({ nodes: landings });
 
     const [permissionsType, setPermissionsType] = useState<"settings">();
 
@@ -58,7 +47,7 @@ export const SettingsPage: React.FC = () => {
 
     return (
         <DhisPage>
-            {landingPageDetailsDialog && <LandingPageEditDialog isOpen={true} {...landingPageDetailsDialog} />}
+            {landingNodeDetailsDialog && <LandingPageEditDialog isOpen={true} {...landingNodeDetailsDialog} />}
 
             {!!permissionsType && (
                 <PermissionsDialog
@@ -83,53 +72,24 @@ export const SettingsPage: React.FC = () => {
 
             <Header title={i18n.t("Settings")} onBackClick={openTraining} />
 
-            <SettingsConfig
-                setPermissionsType={setPermissionsType}
-                buildSharingDescription={buildSharingDescription}
-                modules={modules}
-                landings={landings}
-            />
+            <SettingsConfig setPermissionsType={setPermissionsType} modules={modules} landings={landings} />
 
             <Container>
                 <Title>{i18n.t("General Settings")}</Title>
 
                 <Title>{i18n.t("Landing page")}</Title>
 
-                <LandingPageListTable nodes={landings} isLoading={isLoading} />
+                <LandingPageListTable nodes={landings} isLoading={isLoading} {...actionsDialog} />
 
                 <Title>{i18n.t("Training modules")}</Title>
 
-                <ModuleListTable
-                    rows={buildListModules(modules)}
-                    refreshRows={refreshModules}
-                    tableActions={tableActions}
-                    isLoading={isLoading}
-                />
+                <ModuleListTable rows={buildListModules(modules)} refreshRows={refreshModules} isLoading={isLoading} />
 
-                <CreateButton onAddLandingPage={} />
+                <CreateButton onAddLandingPage={onAddLandingPage} />
             </Container>
         </DhisPage>
     );
 };
-
-function buildSharingDescription(props: Maybe<{ users?: NamedRef[]; userGroups?: NamedRef[] }>) {
-    const { users, userGroups } = { users: [], userGroups: [], ...(props || {}) };
-    const usersCount = users?.length ?? 0;
-    const userGroupsCount = userGroups?.length ?? 0;
-
-    if (usersCount > 0 && userGroupsCount > 0) {
-        return i18n.t("Accessible to {{usersCount}} users and {{userGroupsCount}} user groups", {
-            usersCount,
-            userGroupsCount,
-        });
-    } else if (usersCount > 0) {
-        return i18n.t("Accessible to {{usersCount}} users", { usersCount });
-    } else if (userGroupsCount > 0) {
-        return i18n.t("Accessible to {{userGroupsCount}} user groups", { userGroupsCount });
-    } else {
-        return i18n.t("Only accessible to system administrators");
-    }
-}
 
 const Title = styled.h3`
     margin-top: 25px;

--- a/src/webapp/pages/settings/SettingsPage.tsx
+++ b/src/webapp/pages/settings/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import { ConfirmationDialog, ConfirmationDialogProps, useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
-import { FormGroup, Icon, ListItem, ListItemIcon, ListItemText } from "@material-ui/core";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { NamedRef } from "../../../domain/entities/Ref";
@@ -12,30 +11,26 @@ import {
     updateTranslation,
 } from "../../../domain/helpers/TrainingModuleHelpers";
 import i18n from "../../../utils/i18n";
-import { ComponentParameter } from "../../../types/utils";
+import { ComponentParameter, Maybe } from "../../../types/utils";
 import { LandingPageListTable } from "../../components/landing-page-list-table/LandingPageListTable";
 import { buildListModules, ModuleListTable } from "../../components/module-list-table/ModuleListTable";
 import { PageHeader } from "../../components/page-header/PageHeader";
 import { PermissionsDialog, SharedUpdate } from "../../components/permissions-dialog/PermissionsDialog";
 import { useAppContext } from "../../contexts/app-context";
 import { DhisPage } from "../dhis/DhisPage";
-import { CustomizeSettingsDialog } from "../../components/customize-settings-dialog/CustomizeSettingsDialog";
 import { useAppConfigContext } from "../../contexts/AppConfigProvider";
 import { CreateButton } from "./CreateButton";
 import { LandingPageEditDialog } from "../../components/landing-page-edit-dialog/LandingPageEditDialog";
+import { SettingsConfig } from "./SettingsConfig";
 
 export const SettingsPage: React.FC = () => {
-    const { modules, landings, reload, usecases, setAppState, isLoading, isAdmin } = useAppContext();
+    const { modules, landings, reload, usecases, setAppState, isLoading } = useAppContext();
 
-    const { appConfig, logoInfo, save, hasLoaded } = useAppConfigContext();
+    const { appConfig, save } = useAppConfigContext();
 
     const snackbar = useSnackbar();
-    const loading = useLoading();
 
-    const [permissionsType, setPermissionsType] = useState<string | null>(null);
-    const [showCustomSettings, setShowCustomSettings] = useState(false);
-    const [danglingDocuments, setDanglingDocuments] = useState<NamedRef[]>([]);
-    const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
+    const [permissionsType, setPermissionsType] = useState<"settings">();
 
     const openTraining = useCallback(() => {
         setAppState({ type: "HOME" });
@@ -53,137 +48,9 @@ export const SettingsPage: React.FC = () => {
         [save]
     );
 
-    const closeCustomSettingsDialog = useCallback(() => {
-        setShowCustomSettings(false);
-    }, []);
-
-    const saveCustomSettings = useCallback(
-        async data => {
-            await save(data);
-            closeCustomSettingsDialog();
-        },
-        [save, closeCustomSettingsDialog]
-    );
-
-    const buildSharingDescription = useCallback(() => {
-        const settingsPermissions = appConfig.settingsPermissions;
-        const users = settingsPermissions.users.length;
-        const userGroups = settingsPermissions.userGroups.length;
-
-        if (users > 0 && userGroups > 0) {
-            return i18n.t("Accessible to {{users}} users and {{userGroups}} user groups", {
-                users,
-                userGroups,
-            });
-        } else if (users > 0) {
-            return i18n.t("Accessible to {{users}} users", { users });
-        } else if (userGroups > 0) {
-            return i18n.t("Accessible to {{userGroups}} user groups", { userGroups });
-        } else {
-            return i18n.t("Only accessible to system administrators");
-        }
-    }, [appConfig.settingsPermissions]);
-
-    const cleanUpDanglingDocuments = useCallback(async () => {
-        updateDialog({
-            title: i18n.t("Clean-up unused documents"),
-            description: (
-                <ul>
-                    {danglingDocuments.map(item => (
-                        <li key={item.id}>{`${item.id} ${item.name}`}</li>
-                    ))}
-                </ul>
-            ),
-            onCancel: () => updateDialog(null),
-            onSave: async () => {
-                loading.show(true, i18n.t("Deleting dangling documents"));
-
-                await usecases.document.delete(danglingDocuments.map(({ id }) => id));
-                setDanglingDocuments([]);
-
-                snackbar.success(i18n.t("Deleted dangling documents"));
-                loading.reset();
-                updateDialog(null);
-            },
-            saveText: i18n.t("Proceed"),
-        });
-    }, [danglingDocuments, loading, snackbar, usecases]);
-
     const refreshModules = useCallback(async () => {
         await reload();
     }, [reload]);
-
-    const toggleShowAllModules = useCallback(() => {
-        return save({
-            showAllModules: !appConfig.showAllModules,
-        });
-    }, [appConfig, save]);
-
-    const getModule = React.useCallback(
-        (id: string) => {
-            return usecases.modules.get(id, { autoInstallDefaultModules: true });
-        },
-        [usecases.modules]
-    );
-
-    const openCustomizeSettingsDialog = useCallback(() => setShowCustomSettings(true), []);
-
-    const tableActions: ComponentParameter<typeof ModuleListTable, "tableActions"> = useMemo(
-        () => ({
-            openEditModulePage: ({ id }) => {
-                setAppState({ type: "EDIT_MODULE", module: id });
-            },
-            openCloneModulePage: ({ id }) => {
-                setAppState({ type: "CLONE_MODULE", module: id });
-            },
-            editContents: async ({ id, text, value }) => {
-                const module = await getModule(id);
-                if (module) await usecases.modules.update(updateTranslation(module, text.key, value));
-                else snackbar.error(i18n.t("Unable to update module contents"));
-            },
-            deleteModules: ({ ids }) => usecases.modules.delete(ids),
-            resetModules: ({ ids }) => usecases.modules.resetDefaultValue(ids),
-            swap: async ({ type, id, from, to }) => {
-                if (type === "module") {
-                    await usecases.modules.swapOrder(from, to);
-                    return;
-                }
-
-                const module = await getModule(id);
-                if (module) await usecases.modules.update(updateOrder(module, from, to));
-                else snackbar.error(i18n.t("Unable to move item"));
-            },
-            uploadFile: ({ data, name }) => usecases.document.uploadFile(data, name),
-            installApp: ({ id }) => usecases.instance.installApp(id),
-            addStep: async ({ id, title }) => {
-                const module = await getModule(id);
-                if (module) await usecases.modules.update(addStep(module, title));
-                else snackbar.error(i18n.t("Unable to add step"));
-            },
-            addPage: async ({ id, step, value }) => {
-                const module = await getModule(id);
-                if (module) await usecases.modules.update(addPage(module, step, value));
-                else snackbar.error(i18n.t("Unable to add page"));
-            },
-            deleteStep: async ({ id, step }) => {
-                const module = await getModule(id);
-                if (module) await usecases.modules.update(removeStep(module, step));
-                else snackbar.error(i18n.t("Unable to remove step"));
-            },
-            deletePage: async ({ id, step, page }) => {
-                const module = await getModule(id);
-                if (module) await usecases.modules.update(removePage(module, step, page));
-                else snackbar.error(i18n.t("Unable to remove page"));
-            },
-        }),
-        [usecases, setAppState, snackbar, getModule]
-    );
-
-    useEffect(() => {
-        if (!hasLoaded || isLoading) return;
-        const data = [...modules, ...landings, appConfig];
-        usecases.document.listDangling(data).then(setDanglingDocuments);
-    }, [usecases, modules, landings, appConfig, isLoading, hasLoaded]);
 
     useEffect(() => {
         reload();
@@ -191,17 +58,7 @@ export const SettingsPage: React.FC = () => {
 
     return (
         <DhisPage>
-            {dialogProps && <ConfirmationDialog isOpen={true} maxWidth={"lg"} fullWidth={true} {...dialogProps} />}
             {landingPageDetailsDialog && <LandingPageEditDialog isOpen={true} {...landingPageDetailsDialog} />}
-
-            {showCustomSettings && (
-                <CustomizeSettingsDialog
-                    onSave={saveCustomSettings}
-                    customText={appConfig?.customText ?? emptyObject}
-                    onClose={closeCustomSettingsDialog}
-                    logo={logoInfo.logoPath}
-                />
-            )}
 
             {!!permissionsType && (
                 <PermissionsDialog
@@ -220,67 +77,21 @@ export const SettingsPage: React.FC = () => {
                             })) ?? [],
                     }}
                     onChange={updateSettingsPermissions}
-                    onClose={() => setPermissionsType(null)}
+                    onClose={() => setPermissionsType(undefined)}
                 />
             )}
 
             <Header title={i18n.t("Settings")} onBackClick={openTraining} />
 
+            <SettingsConfig
+                setPermissionsType={setPermissionsType}
+                buildSharingDescription={buildSharingDescription}
+                modules={modules}
+                landings={landings}
+            />
+
             <Container>
                 <Title>{i18n.t("General Settings")}</Title>
-
-                <Group row={true}>
-                    <ListItem button onClick={() => setPermissionsType("settings")}>
-                        <ListItemIcon>
-                            <Icon>settings</Icon>
-                        </ListItemIcon>
-                        <ListItemText primary={i18n.t("Access to Settings")} secondary={buildSharingDescription()} />
-                    </ListItem>
-
-                    <ListItem button onClick={toggleShowAllModules}>
-                        {appConfig.showAllModules}
-
-                        <ListItemIcon>
-                            <Icon>{appConfig.showAllModules ? "visibility" : "visibility_off"}</Icon>
-                        </ListItemIcon>
-                        <ListItemText
-                            primary={i18n.t("Show list with modules on main landing page")}
-                            secondary={
-                                appConfig.showAllModules
-                                    ? i18n.t("A list with all the existing modules is visible")
-                                    : i18n.t("The list with all the existing  modules is hidden")
-                            }
-                        />
-                    </ListItem>
-
-                    <ListItem button onClick={openCustomizeSettingsDialog}>
-                        <ListItemIcon>
-                            <Icon>format_shapes</Icon>
-                        </ListItemIcon>
-                        <ListItemText
-                            primary={i18n.t("Customize the landing page")}
-                            secondary={i18n.t("Update the logo or content")}
-                        />
-                    </ListItem>
-
-                    {isAdmin && (
-                        <ListItem button disabled={danglingDocuments.length === 0} onClick={cleanUpDanglingDocuments}>
-                            <ListItemIcon>
-                                <Icon>delete_forever</Icon>
-                            </ListItemIcon>
-                            <ListItemText
-                                primary={i18n.t("Clean-up unused documents")}
-                                secondary={
-                                    danglingDocuments.length === 0
-                                        ? i18n.t("There are no unused documents to clean")
-                                        : i18n.t("There are {{total}} documents available to clean", {
-                                              total: danglingDocuments.length,
-                                          })
-                                }
-                            />
-                        </ListItem>
-                    )}
-                </Group>
 
                 <Title>{i18n.t("Landing page")}</Title>
 
@@ -301,15 +112,27 @@ export const SettingsPage: React.FC = () => {
     );
 };
 
-const emptyObject = {};
+function buildSharingDescription(props: Maybe<{ users?: NamedRef[]; userGroups?: NamedRef[] }>) {
+    const { users, userGroups } = { users: [], userGroups: [], ...(props || {}) };
+    const usersCount = users?.length ?? 0;
+    const userGroupsCount = userGroups?.length ?? 0;
+
+    if (usersCount > 0 && userGroupsCount > 0) {
+        return i18n.t("Accessible to {{usersCount}} users and {{userGroupsCount}} user groups", {
+            usersCount,
+            userGroupsCount,
+        });
+    } else if (usersCount > 0) {
+        return i18n.t("Accessible to {{usersCount}} users", { usersCount });
+    } else if (userGroupsCount > 0) {
+        return i18n.t("Accessible to {{userGroupsCount}} user groups", { userGroupsCount });
+    } else {
+        return i18n.t("Only accessible to system administrators");
+    }
+}
 
 const Title = styled.h3`
     margin-top: 25px;
-`;
-
-const Group = styled(FormGroup)`
-    margin-bottom: 35px;
-    margin-left: 0;
 `;
 
 const Container = styled.div`

--- a/src/webapp/pages/settings/SettingsPage.tsx
+++ b/src/webapp/pages/settings/SettingsPage.tsx
@@ -21,6 +21,8 @@ import { useAppContext } from "../../contexts/app-context";
 import { DhisPage } from "../dhis/DhisPage";
 import { CustomizeSettingsDialog } from "../../components/customize-settings-dialog/CustomizeSettingsDialog";
 import { useAppConfigContext } from "../../contexts/AppConfigProvider";
+import { CreateButton } from "./CreateButton";
+import { LandingPageEditDialog } from "../../components/landing-page-edit-dialog/LandingPageEditDialog";
 
 export const SettingsPage: React.FC = () => {
     const { modules, landings, reload, usecases, setAppState, isLoading, isAdmin } = useAppContext();
@@ -111,10 +113,6 @@ export const SettingsPage: React.FC = () => {
         await reload();
     }, [reload]);
 
-    const openAddModule = useCallback(() => {
-        setAppState({ type: "CREATE_MODULE" });
-    }, [setAppState]);
-
     const toggleShowAllModules = useCallback(() => {
         return save({
             showAllModules: !appConfig.showAllModules,
@@ -194,6 +192,8 @@ export const SettingsPage: React.FC = () => {
     return (
         <DhisPage>
             {dialogProps && <ConfirmationDialog isOpen={true} maxWidth={"lg"} fullWidth={true} {...dialogProps} />}
+            {landingPageDetailsDialog && <LandingPageEditDialog isOpen={true} {...landingPageDetailsDialog} />}
+
             {showCustomSettings && (
                 <CustomizeSettingsDialog
                     onSave={saveCustomSettings}
@@ -292,9 +292,10 @@ export const SettingsPage: React.FC = () => {
                     rows={buildListModules(modules)}
                     refreshRows={refreshModules}
                     tableActions={tableActions}
-                    onActionButtonClick={openAddModule}
                     isLoading={isLoading}
                 />
+
+                <CreateButton onAddLandingPage={} />
             </Container>
         </DhisPage>
     );

--- a/src/webapp/pages/settings/SettingsPage.tsx
+++ b/src/webapp/pages/settings/SettingsPage.tsx
@@ -1,13 +1,11 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect } from "react";
 import styled from "styled-components";
 import i18n from "../../../utils/i18n";
 import { LandingPageListTable } from "../../components/landing-page-list-table/LandingPageListTable";
 import { buildListModules, ModuleListTable } from "../../components/module-list-table/ModuleListTable";
 import { PageHeader } from "../../components/page-header/PageHeader";
-import { PermissionsDialog, SharedUpdate } from "../../components/permissions-dialog/PermissionsDialog";
 import { useAppContext } from "../../contexts/app-context";
 import { DhisPage } from "../dhis/DhisPage";
-import { useAppConfigContext } from "../../contexts/AppConfigProvider";
 import { CreateButton } from "./CreateButton";
 import { LandingPageEditDialog } from "../../components/landing-page-edit-dialog/LandingPageEditDialog";
 import { SettingsConfig } from "./SettingsConfig";
@@ -15,27 +13,11 @@ import { useLandingNodeDialog } from "./useLandingNodeDialog";
 
 export const SettingsPage: React.FC = () => {
     const { modules, landings, reload, setAppState, isLoading } = useAppContext();
-
-    const { appConfig, save } = useAppConfigContext();
     const { landingNodeDetailsDialog, onAddLandingPage, ...actionsDialog } = useLandingNodeDialog({ nodes: landings });
-
-    const [permissionsType, setPermissionsType] = useState<"settings">();
 
     const openTraining = useCallback(() => {
         setAppState({ type: "HOME" });
     }, [setAppState]);
-
-    const updateSettingsPermissions = useCallback(
-        async ({ userAccesses, userGroupAccesses }: SharedUpdate) => {
-            return save({
-                settingsPermissions: {
-                    users: userAccesses?.map(({ id, name }) => ({ id, name })),
-                    userGroups: userGroupAccesses?.map(({ id, name }) => ({ id, name })),
-                },
-            });
-        },
-        [save]
-    );
 
     const refreshModules = useCallback(async () => {
         await reload();
@@ -49,33 +31,11 @@ export const SettingsPage: React.FC = () => {
         <DhisPage>
             {landingNodeDetailsDialog && <LandingPageEditDialog isOpen={true} {...landingNodeDetailsDialog} />}
 
-            {!!permissionsType && (
-                <PermissionsDialog
-                    object={{
-                        name: "Access to settings",
-                        publicAccess: "--------",
-                        userAccesses:
-                            appConfig.settingsPermissions.users.map(ref => ({
-                                ...ref,
-                                access: "rw----",
-                            })) ?? [],
-                        userGroupAccesses:
-                            appConfig.settingsPermissions.userGroups.map(ref => ({
-                                ...ref,
-                                access: "rw----",
-                            })) ?? [],
-                    }}
-                    onChange={updateSettingsPermissions}
-                    onClose={() => setPermissionsType(undefined)}
-                />
-            )}
-
             <Header title={i18n.t("Settings")} onBackClick={openTraining} />
-
-            <SettingsConfig setPermissionsType={setPermissionsType} modules={modules} landings={landings} />
 
             <Container>
                 <Title>{i18n.t("General Settings")}</Title>
+                <SettingsConfig modules={modules} landings={landings} />
 
                 <Title>{i18n.t("Landing page")}</Title>
 

--- a/src/webapp/pages/settings/useLandingNodeActions.ts
+++ b/src/webapp/pages/settings/useLandingNodeActions.ts
@@ -1,13 +1,9 @@
 import { useCallback } from "react";
 import _ from "lodash";
 import i18n from "../../../utils/i18n";
-import { LandingNode } from "../../../domain/entities/LandingPage";
+import { flattenNodes, LandingNode } from "../../../domain/entities/LandingPage";
 import { useAppContext } from "../../contexts/app-context";
 import { LandingPageEditDialogProps } from "../../components/landing-page-edit-dialog/LandingPageEditDialog";
-
-const flattenRows = (rows: LandingNode[]): LandingNode[] => {
-    return _.flatMap(rows, row => [row, ...flattenRows(row.children)]);
-};
 
 export function useLandingNodeActions(
     nodes: LandingNode[],
@@ -37,7 +33,7 @@ export function useLandingNodeActions(
 
     const onAddSection = useCallback(
         (ids: string[]) => {
-            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            const parent = flattenNodes(nodes).find(({ id }) => id === ids[0]);
             if (!parent) return;
 
             setDialogProps({
@@ -54,7 +50,7 @@ export function useLandingNodeActions(
 
     const onAddSubSection = useCallback(
         (ids: string[]) => {
-            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            const parent = flattenNodes(nodes).find(({ id }) => id === ids[0]);
             if (!parent) return;
 
             setDialogProps({
@@ -71,7 +67,7 @@ export function useLandingNodeActions(
 
     const onAddCategory = useCallback(
         (ids: string[]) => {
-            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            const parent = flattenNodes(nodes).find(({ id }) => id === ids[0]);
             if (!parent) return;
 
             setDialogProps({
@@ -88,7 +84,7 @@ export function useLandingNodeActions(
 
     const onEditLandingNode = useCallback(
         (ids: string[]) => {
-            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            const parent = flattenNodes(nodes).find(({ id }) => id === ids[0]);
             if (!parent) return;
 
             setDialogProps({

--- a/src/webapp/pages/settings/useLandingNodeActions.ts
+++ b/src/webapp/pages/settings/useLandingNodeActions.ts
@@ -25,7 +25,7 @@ export function useLandingNodeActions(
             title: i18n.t("Add Landing Page"),
             type: "root",
             parent: "none",
-            order: 0,
+            order: nodes.length,
             onCancel: () => setDialogProps(undefined),
             onSave: doSaveLandingNode,
         });

--- a/src/webapp/pages/settings/useLandingNodeActions.ts
+++ b/src/webapp/pages/settings/useLandingNodeActions.ts
@@ -1,15 +1,18 @@
 import { useCallback } from "react";
 import _ from "lodash";
-import i18n from "../../utils/i18n";
-import { LandingNode } from "../../domain/entities/LandingPage";
-import { useAppContext } from "../contexts/app-context";
-import { LandingPageEditDialogProps } from "../components/landing-page-edit-dialog/LandingPageEditDialog";
+import i18n from "../../../utils/i18n";
+import { LandingNode } from "../../../domain/entities/LandingPage";
+import { useAppContext } from "../../contexts/app-context";
+import { LandingPageEditDialogProps } from "../../components/landing-page-edit-dialog/LandingPageEditDialog";
 
 const flattenRows = (rows: LandingNode[]): LandingNode[] => {
     return _.flatMap(rows, row => [row, ...flattenRows(row.children)]);
 };
 
-export function useLandingNodeActions(nodes: LandingNode[], setDialogProps: (props: LandingPageEditDialogProps | undefined) => void) {
+export function useLandingNodeActions(
+    nodes: LandingNode[],
+    setDialogProps: (props: LandingPageEditDialogProps | undefined) => void
+) {
     const { usecases, reload } = useAppContext();
 
     const doSaveLandingNode = useCallback(

--- a/src/webapp/pages/settings/useLandingNodeActions.ts
+++ b/src/webapp/pages/settings/useLandingNodeActions.ts
@@ -1,5 +1,4 @@
 import { useCallback } from "react";
-import _ from "lodash";
 import i18n from "../../../utils/i18n";
 import { flattenNodes, LandingNode } from "../../../domain/entities/LandingPage";
 import { useAppContext } from "../../contexts/app-context";
@@ -29,7 +28,7 @@ export function useLandingNodeActions(
             onCancel: () => setDialogProps(undefined),
             onSave: doSaveLandingNode,
         });
-    }, [doSaveLandingNode, setDialogProps]);
+    }, [doSaveLandingNode, setDialogProps, nodes]);
 
     const onAddSection = useCallback(
         (ids: string[]) => {

--- a/src/webapp/pages/settings/useLandingNodeDialog.ts
+++ b/src/webapp/pages/settings/useLandingNodeDialog.ts
@@ -1,8 +1,9 @@
 import { useCallback, useState } from "react";
+import _ from "lodash";
+
 import { LandingPageEditDialogProps } from "../../components/landing-page-edit-dialog/LandingPageEditDialog";
 import i18n from "../../../utils/i18n";
 import { LandingNode } from "../../../domain/entities/LandingPage";
-import _ from "lodash";
 import { useAppContext } from "../../contexts/app-context";
 
 export function useLandingNodeDialog(props: { nodes: LandingNode[] }) {

--- a/src/webapp/pages/settings/useLandingNodeDialog.ts
+++ b/src/webapp/pages/settings/useLandingNodeDialog.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { LandingPageEditDialogProps } from "../../components/landing-page-edit-dialog/LandingPageEditDialog";
 import { LandingNode } from "../../../domain/entities/LandingPage";
-import { useLandingNodeActions } from "../../hooks/useLandingNodeActions";
+import { useLandingNodeActions } from "./useLandingNodeActions";
 
 export function useLandingNodeDialog(props: { nodes: LandingNode[] }) {
     const { nodes } = props;

--- a/src/webapp/pages/settings/useLandingNodeDialog.ts
+++ b/src/webapp/pages/settings/useLandingNodeDialog.ts
@@ -1,0 +1,114 @@
+import { useCallback, useState } from "react";
+import { LandingPageEditDialogProps } from "../../components/landing-page-edit-dialog/LandingPageEditDialog";
+import i18n from "../../../utils/i18n";
+import { LandingNode } from "../../../domain/entities/LandingPage";
+import _ from "lodash";
+import { useAppContext } from "../../contexts/app-context";
+
+export function useLandingNodeDialog(props: { nodes: LandingNode[] }) {
+    const { nodes } = props;
+    const { usecases, reload } = useAppContext();
+    const [landingNodeDetailsDialog, setLandingNodeDetailsDialog] = useState<LandingPageEditDialogProps>();
+
+    const doSaveLandingNode = useCallback(
+        async (node: LandingNode) => {
+            setLandingNodeDetailsDialog(undefined);
+            await usecases.landings.update(node);
+            await reload();
+        },
+        [reload, usecases]
+    );
+
+    const onAddLandingPage = useCallback(() => {
+        setLandingNodeDetailsDialog({
+            title: i18n.t("Add Landing Page"),
+            type: "root",
+            parent: "none",
+            order: 0,
+            onCancel: () => setLandingNodeDetailsDialog(undefined),
+            onSave: doSaveLandingNode,
+        });
+    }, [doSaveLandingNode]);
+
+    const onAddSection = useCallback(
+        (ids: string[]) => {
+            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            if (!parent) return;
+
+            setLandingNodeDetailsDialog({
+                title: i18n.t("Add section"),
+                type: "section",
+                parent: parent.id,
+                order: parent.children.length,
+                onCancel: () => setLandingNodeDetailsDialog(undefined),
+                onSave: doSaveLandingNode,
+            });
+        },
+        [doSaveLandingNode, nodes]
+    );
+
+    const onAddSubSection = useCallback(
+        (ids: string[]) => {
+            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            if (!parent) return;
+
+            setLandingNodeDetailsDialog({
+                title: i18n.t("Add sub-section"),
+                type: "sub-section",
+                parent: parent.id,
+                order: parent.children.length,
+                onCancel: () => setLandingNodeDetailsDialog(undefined),
+                onSave: doSaveLandingNode,
+            });
+        },
+        [doSaveLandingNode, nodes]
+    );
+
+    const onAddCategory = useCallback(
+        (ids: string[]) => {
+            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            if (!parent) return;
+
+            setLandingNodeDetailsDialog({
+                title: i18n.t("Add category"),
+                type: "category",
+                parent: parent.id,
+                order: parent.children.length,
+                onCancel: () => setLandingNodeDetailsDialog(undefined),
+                onSave: doSaveLandingNode,
+            });
+        },
+        [doSaveLandingNode, nodes]
+    );
+
+    const onEditLandingNode = useCallback(
+        (ids: string[]) => {
+            const node = flattenRows(nodes).find(({ id }) => id === ids[0]);
+            if (!node) return;
+
+            setLandingNodeDetailsDialog({
+                title: i18n.t("Edit"),
+                type: node.type,
+                parent: node.parent,
+                initialNode: node,
+                order: node.order ?? 0,
+                onCancel: () => setLandingNodeDetailsDialog(undefined),
+                onSave: doSaveLandingNode,
+            });
+        },
+        [doSaveLandingNode, nodes]
+    );
+
+    return {
+        landingNodeDetailsDialog,
+        onAddSection,
+        onAddSubSection,
+        onAddCategory,
+        onEditLandingNode,
+        onAddLandingPage,
+    };
+}
+
+const flattenRows = (rows: LandingNode[]): LandingNode[] => {
+    return _.flatMap(rows, row => [row, ...flattenRows(row.children)]);
+};

--- a/src/webapp/pages/settings/useLandingNodeDialog.ts
+++ b/src/webapp/pages/settings/useLandingNodeDialog.ts
@@ -1,115 +1,17 @@
-import { useCallback, useState } from "react";
-import _ from "lodash";
+import { useState } from "react";
 
 import { LandingPageEditDialogProps } from "../../components/landing-page-edit-dialog/LandingPageEditDialog";
-import i18n from "../../../utils/i18n";
 import { LandingNode } from "../../../domain/entities/LandingPage";
-import { useAppContext } from "../../contexts/app-context";
+import { useLandingNodeActions } from "../../hooks/useLandingNodeActions";
 
 export function useLandingNodeDialog(props: { nodes: LandingNode[] }) {
     const { nodes } = props;
-    const { usecases, reload } = useAppContext();
     const [landingNodeDetailsDialog, setLandingNodeDetailsDialog] = useState<LandingPageEditDialogProps>();
 
-    const doSaveLandingNode = useCallback(
-        async (node: LandingNode) => {
-            setLandingNodeDetailsDialog(undefined);
-            await usecases.landings.update(node);
-            await reload();
-        },
-        [reload, usecases]
-    );
-
-    const onAddLandingPage = useCallback(() => {
-        setLandingNodeDetailsDialog({
-            title: i18n.t("Add Landing Page"),
-            type: "root",
-            parent: "none",
-            order: 0,
-            onCancel: () => setLandingNodeDetailsDialog(undefined),
-            onSave: doSaveLandingNode,
-        });
-    }, [doSaveLandingNode]);
-
-    const onAddSection = useCallback(
-        (ids: string[]) => {
-            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
-            if (!parent) return;
-
-            setLandingNodeDetailsDialog({
-                title: i18n.t("Add section"),
-                type: "section",
-                parent: parent.id,
-                order: parent.children.length,
-                onCancel: () => setLandingNodeDetailsDialog(undefined),
-                onSave: doSaveLandingNode,
-            });
-        },
-        [doSaveLandingNode, nodes]
-    );
-
-    const onAddSubSection = useCallback(
-        (ids: string[]) => {
-            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
-            if (!parent) return;
-
-            setLandingNodeDetailsDialog({
-                title: i18n.t("Add sub-section"),
-                type: "sub-section",
-                parent: parent.id,
-                order: parent.children.length,
-                onCancel: () => setLandingNodeDetailsDialog(undefined),
-                onSave: doSaveLandingNode,
-            });
-        },
-        [doSaveLandingNode, nodes]
-    );
-
-    const onAddCategory = useCallback(
-        (ids: string[]) => {
-            const parent = flattenRows(nodes).find(({ id }) => id === ids[0]);
-            if (!parent) return;
-
-            setLandingNodeDetailsDialog({
-                title: i18n.t("Add category"),
-                type: "category",
-                parent: parent.id,
-                order: parent.children.length,
-                onCancel: () => setLandingNodeDetailsDialog(undefined),
-                onSave: doSaveLandingNode,
-            });
-        },
-        [doSaveLandingNode, nodes]
-    );
-
-    const onEditLandingNode = useCallback(
-        (ids: string[]) => {
-            const node = flattenRows(nodes).find(({ id }) => id === ids[0]);
-            if (!node) return;
-
-            setLandingNodeDetailsDialog({
-                title: i18n.t("Edit"),
-                type: node.type,
-                parent: node.parent,
-                initialNode: node,
-                order: node.order ?? 0,
-                onCancel: () => setLandingNodeDetailsDialog(undefined),
-                onSave: doSaveLandingNode,
-            });
-        },
-        [doSaveLandingNode, nodes]
-    );
+    const actions = useLandingNodeActions(nodes, setLandingNodeDetailsDialog);
 
     return {
         landingNodeDetailsDialog,
-        onAddSection,
-        onAddSubSection,
-        onAddCategory,
-        onEditLandingNode,
-        onAddLandingPage,
+        ...actions,
     };
 }
-
-const flattenRows = (rows: LandingNode[]): LandingNode[] => {
-    return _.flatMap(rows, row => [row, ...flattenRows(row.children)]);
-};

--- a/src/webapp/utils/sharing-settings.ts
+++ b/src/webapp/utils/sharing-settings.ts
@@ -1,11 +1,10 @@
 import i18n from "../../utils/i18n";
-import { Maybe } from "../../types/utils";
 import { NamedRef } from "../../domain/entities/Ref";
 import { Permission } from "../../domain/entities/Permission";
 import { PermissionsDialogProps } from "../components/permissions-dialog/PermissionsDialog";
 
-export function buildSharingDescription(props: Maybe<{ users?: NamedRef[]; userGroups?: NamedRef[] }>) {
-    const { users, userGroups } = { users: [], userGroups: [], ...(props || {}) };
+export function buildSharingDescription(props: { users: NamedRef[]; userGroups: NamedRef[] }) {
+    const { users, userGroups } = props;
     const usersCount = users?.length ?? 0;
     const userGroupsCount = userGroups?.length ?? 0;
 

--- a/src/webapp/utils/sharing-settings.ts
+++ b/src/webapp/utils/sharing-settings.ts
@@ -1,6 +1,8 @@
 import i18n from "../../utils/i18n";
 import { Maybe } from "../../types/utils";
 import { NamedRef } from "../../domain/entities/Ref";
+import { Permission } from "../../domain/entities/Permission";
+import { PermissionsDialogProps } from "../components/permissions-dialog/PermissionsDialog";
 
 export function buildSharingDescription(props: Maybe<{ users?: NamedRef[]; userGroups?: NamedRef[] }>) {
     const { users, userGroups } = { users: [], userGroups: [], ...(props || {}) };
@@ -19,4 +21,26 @@ export function buildSharingDescription(props: Maybe<{ users?: NamedRef[]; userG
     } else {
         return i18n.t("Only accessible to system administrators");
     }
+}
+
+export function buildSettingsPermissionDialogProps(props: {
+    permissions: Permission;
+    name: string;
+    publicAccess?: string;
+}): PermissionsDialogProps["object"] {
+    const { permissions, name, publicAccess } = props;
+    return {
+        name: name,
+        publicAccess: publicAccess || "--------",
+        userAccesses:
+            permissions.users.map(ref => ({
+                ...ref,
+                access: "rw----",
+            })) ?? [],
+        userGroupAccesses:
+            permissions.userGroups.map(ref => ({
+                ...ref,
+                access: "rw----",
+            })) ?? [],
+    };
 }

--- a/src/webapp/utils/sharing-settings.ts
+++ b/src/webapp/utils/sharing-settings.ts
@@ -1,0 +1,22 @@
+import i18n from "../../utils/i18n";
+import { Maybe } from "../../types/utils";
+import { NamedRef } from "../../domain/entities/Ref";
+
+export function buildSharingDescription(props: Maybe<{ users?: NamedRef[]; userGroups?: NamedRef[] }>) {
+    const { users, userGroups } = { users: [], userGroups: [], ...(props || {}) };
+    const usersCount = users?.length ?? 0;
+    const userGroupsCount = userGroups?.length ?? 0;
+
+    if (usersCount > 0 && userGroupsCount > 0) {
+        return i18n.t("Accessible to {{usersCount}} users and {{userGroupsCount}} user groups", {
+            usersCount,
+            userGroupsCount,
+        });
+    } else if (usersCount > 0) {
+        return i18n.t("Accessible to {{usersCount}} users", { usersCount });
+    } else if (userGroupsCount > 0) {
+        return i18n.t("Accessible to {{userGroupsCount}} user groups", { userGroupsCount });
+    } else {
+        return i18n.t("Only accessible to system administrators");
+    }
+}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8699jdpw5 [[Training App] Support for multiple landing pages](https://app.clickup.com/t/8699jdpw5)

#### :exclamation::exclamation: Additional Fix :exclamation: :exclamation:
Settings permission -> the function responsible for saving permissions is storing either users or groups—but not both. 
- added persisted config model
- Updated save config to avoid overwriting users or groups
- refactor to perform default and saved config in dataModel instead of use case


### :memo: Implementation 
- migrate customizations (customText and customized logo) to main (now default) landing page
- fetch multiple root landing nodes
- add landing root landing node and sharing settings 
- filter **user** landing nodes in home page
- show `MainLandingPage` if user has multiple landing pages

### **Additional Details**
- minor refactor
    - rename of methods: `updateChild -> update` and `removeChilds -> delete` 
     - removed `swapOrder` from repository and perform reordering in usecase
- updates StorageClient to allow multiple saving while preserving item order
- remove null from `Maybe`
- Refactor components - move parts into components

### :video_camera: Screenshots/Screen capture

### :fire: How to test it? (If there is any special consideration or the reviewer does not know how to test it)

### :bookmark_tabs: Others

-   [ ] Any change in the [API repo](https://github.com/EyeSeeTea/d2-api)? If so, what branch/PR?
-   [ ] Any change in the [GUI library](https://github.com/EyeSeeTea/d2-ui-components)? If so, what branch/PR?
